### PR TITLE
fix: Restarts broken due to invalid progress data

### DIFF
--- a/library/src/main/java/com/mux/video/upload/MuxUploadSdk.kt
+++ b/library/src/main/java/com/mux/video/upload/MuxUploadSdk.kt
@@ -47,7 +47,7 @@ object MuxUploadSdk {
     httpClient = OkHttpClient.Builder()
       .addInterceptor(HttpLoggingInterceptor {
         logger.v("MuxUploadHttp", it)
-      }.apply { setLevel(HttpLoggingInterceptor.Level.BODY) })
+      }.apply { setLevel(HttpLoggingInterceptor.Level.HEADERS) })
       // these are high timeouts even uploading large files, but it's better to err on the high side
       .callTimeout(10, TimeUnit.MINUTES)  // 10 minutes per chunk
       .writeTimeout(1, TimeUnit.MINUTES) // 1 minute per packet
@@ -63,7 +63,6 @@ object MuxUploadSdk {
 
     if (resumeStoppedUploads)  {
       val upl = MuxUploadManager.resumeAllCachedJobs()
-      Log.d("NOURL", "Attempting upload $upl")
     }
   }
 

--- a/library/src/main/java/com/mux/video/upload/MuxUploadSdk.kt
+++ b/library/src/main/java/com/mux/video/upload/MuxUploadSdk.kt
@@ -47,7 +47,7 @@ object MuxUploadSdk {
     httpClient = OkHttpClient.Builder()
       .addInterceptor(HttpLoggingInterceptor {
         logger.v("MuxUploadHttp", it)
-      }.apply { setLevel(HttpLoggingInterceptor.Level.HEADERS) })
+      }.apply { setLevel(HttpLoggingInterceptor.Level.BODY) })
       // these are high timeouts even uploading large files, but it's better to err on the high side
       .callTimeout(10, TimeUnit.MINUTES)  // 10 minutes per chunk
       .writeTimeout(1, TimeUnit.MINUTES) // 1 minute per packet

--- a/library/src/main/java/com/mux/video/upload/MuxUploadSdk.kt
+++ b/library/src/main/java/com/mux/video/upload/MuxUploadSdk.kt
@@ -62,7 +62,8 @@ object MuxUploadSdk {
     UploadMetrics.initialize(appContext)
 
     if (resumeStoppedUploads)  {
-      MuxUploadManager.resumeAllCachedJobs()
+      val upl = MuxUploadManager.resumeAllCachedJobs()
+      Log.d("NOURL", "Attempting upload $upl")
     }
   }
 

--- a/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
@@ -156,13 +156,13 @@ object MuxUploadManager {
   private fun newObserveProgressJob(upload: UploadInfo): Job {
     // This job has up to three children, one for each of the state flows on UploadInfo
     return mainScope.launch {
-      upload.progressFlow?.let { flow ->
-        launch {
-          flow.collect { state ->
-            launch(Dispatchers.IO) { writeUploadState(upload, state) }
-          }
-        }
-      }
+//      upload.progressFlow?.let { flow ->
+//        launch {
+//          flow.collect { state ->
+//            launch(Dispatchers.IO) { writeUploadState(upload, state) }
+//          }
+//        }
+//      }
 
       upload.successFlow?.let { flow -> launch { flow.collect { jobFinished(upload) } } }
     }

--- a/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
@@ -38,7 +38,6 @@ object MuxUploadManager {
    */
   fun resumeAllCachedJobs(): List<MuxUpload> {
     return readAllCachedUploads()
-      //.onEach { uploadInfo -> Log.d("NOURL","read in $uploadInfo") }
       .onEach { uploadInfo -> startJob(uploadInfo, restart = false) }
       .map { MuxUpload.create(it) }
   }

--- a/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
@@ -155,14 +155,6 @@ object MuxUploadManager {
   private fun newObserveProgressJob(upload: UploadInfo): Job {
     // This job has up to three children, one for each of the state flows on UploadInfo
     return mainScope.launch {
-//      upload.progressFlow?.let { flow ->
-//        launch {
-//          flow.collect { state ->
-//            launch(Dispatchers.IO) { writeUploadState(upload, state) }
-//          }
-//        }
-//      }
-
       upload.successFlow?.let { flow -> launch { flow.collect { jobFinished(upload) } } }
     }
   }

--- a/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
@@ -1,5 +1,6 @@
 package com.mux.video.upload.api
 
+import android.util.Log
 import androidx.annotation.MainThread
 import com.mux.video.upload.MuxUploadSdk
 import com.mux.video.upload.internal.*
@@ -37,6 +38,7 @@ object MuxUploadManager {
    */
   fun resumeAllCachedJobs(): List<MuxUpload> {
     return readAllCachedUploads()
+      //.onEach { uploadInfo -> Log.d("NOURL","read in $uploadInfo") }
       .onEach { uploadInfo -> startJob(uploadInfo, restart = false) }
       .map { MuxUpload.create(it) }
   }

--- a/library/src/main/java/com/mux/video/upload/internal/ChunkWorker.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/ChunkWorker.kt
@@ -19,9 +19,8 @@ import java.io.IOException
  */
 internal class ChunkWorker private constructor(
   private val chunk: Chunk,
-  private val maxRetries: Int,
+  private val uploadInfo: UploadInfo,
   private val videoMimeType: String,
-  private val remoteUri: Uri,
   private val progressFlow: MutableSharedFlow<MuxUpload.Progress>,
 ) {
   companion object {
@@ -33,11 +32,10 @@ internal class ChunkWorker private constructor(
     @JvmSynthetic
     internal fun create(
       chunk: Chunk,
-      maxRetries: Int,
+      uploadInfo: UploadInfo,
       videoMimeType: String,
-      remoteUri: Uri,
       progressFlow: MutableSharedFlow<MuxUpload.Progress>,
-    ): ChunkWorker = ChunkWorker(chunk, maxRetries, videoMimeType, remoteUri, progressFlow)
+    ): ChunkWorker = ChunkWorker(chunk, uploadInfo, videoMimeType, progressFlow)
   }
 
   private val logger get() = MuxUploadSdk.logger
@@ -47,7 +45,7 @@ internal class ChunkWorker private constructor(
 
   @Throws
   suspend fun upload(): MuxUpload.Progress {
-    val moreRetries = { triesSoFar: Int -> triesSoFar < maxRetries }
+    val moreRetries = { triesSoFar: Int -> triesSoFar < uploadInfo.retriesPerChunk }
     suspend fun tryUpload(triesSoFar: Int): Result<MuxUpload.Progress> {
       try {
         val (finalState, httpResponse) = doUpload()
@@ -55,7 +53,6 @@ internal class ChunkWorker private constructor(
           // End Case: Chunk success!
           return Result.success(finalState)
         } else if (RETRYABLE_STATUS_CODES.contains(httpResponse.code)) {
-          Log.d("MuxUploadHttp", "Retrying")
           return if (moreRetries(triesSoFar)) {
             // Still have more retries so try again
             tryUpload(triesSoFar + 1)
@@ -79,7 +76,7 @@ internal class ChunkWorker private constructor(
       }
     }
 
-    return tryUpload(0).getOrThrow()
+    return tryUpload(0).getOrThrow().also { writeUploadState(uploadInfo, it) }
   }
 
   @Throws
@@ -118,7 +115,7 @@ internal class ChunkWorker private constructor(
         } // stream.asCountingRequestBody
 
       val request = Request.Builder()
-        .url(remoteUri.toString())
+        .url(uploadInfo.remoteUri.toString())
         .put(putBody)
         .header("Content-Type", videoMimeType)
         .header(

--- a/library/src/main/java/com/mux/video/upload/internal/UploadJobFactory.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadJobFactory.kt
@@ -48,8 +48,7 @@ internal class UploadJobFactory private constructor(
       progressFlow: MutableSharedFlow<MuxUpload.Progress>
     ): ChunkWorker = ChunkWorker.create(
       chunk = chunk,
-      maxRetries = uploadInfo.retriesPerChunk,
-      remoteUri = uploadInfo.remoteUri,
+      uploadInfo = uploadInfo,
       videoMimeType = MIME_TYPE_GENERIC_VIDEO,
       progressFlow = progressFlow,
     )

--- a/library/src/main/java/com/mux/video/upload/internal/UploadPersistence.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadPersistence.kt
@@ -103,6 +103,7 @@ private object UploadPersistence {
   }
 
   @Throws
+  @Synchronized
   private fun writeEntries(entries: Map<String, UploadEntry>) {
     val entriesJson = JSONArray()
     entries.forEach { entriesJson.put(it.value.toJson()) }
@@ -110,6 +111,7 @@ private object UploadPersistence {
   }
 
   @Throws
+  @Synchronized
   private fun fetchEntries(): MutableMap<String, UploadEntry> {
     val jsonStr = prefs.getString(LIST_KEY, null)
     return if (jsonStr == null) {

--- a/library/src/main/java/com/mux/video/upload/internal/UploadPersistence.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadPersistence.kt
@@ -154,8 +154,6 @@ private data class UploadEntry(
   val bytesSent: Long,
 ) {
   fun toJson(): JSONObject {
-    Log.d("NOURL", "Writing URL $url")
-    Log.d("NOURL", "bytes $bytesSent")
     return JSONObject().apply {
       put("file", file.absolutePath)
       put("data", JSONObject().apply {

--- a/library/src/main/java/com/mux/video/upload/internal/UploadPersistence.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadPersistence.kt
@@ -3,6 +3,7 @@ package com.mux.video.upload.internal
 import android.content.Context
 import android.content.SharedPreferences
 import android.net.Uri
+import android.util.Log
 import com.mux.video.upload.api.MuxUpload
 import org.json.JSONArray
 import org.json.JSONObject
@@ -46,18 +47,20 @@ internal fun forgetUploadState(uploadInfo: UploadInfo) {
 
 @JvmSynthetic
 internal fun readAllCachedUploads(): List<UploadInfo> {
-  return UploadPersistence.readEntries().map { it.value }.map {
-    UploadInfo(
-      remoteUri = Uri.parse(it.url),
-      file =  it.file,
-      chunkSize = it.chunkSize,
-      retriesPerChunk = it.retriesPerChunk,
-      optOut = it.optOut,
-      uploadJob = null,
-      successFlow = null,
-      progressFlow = null,
-      errorFlow = null,
-    )
+  return UploadPersistence.readEntries()
+    .map { it.value }
+    .map {
+      UploadInfo(
+        remoteUri = Uri.parse(it.url),
+        file =  it.file,
+        chunkSize = it.chunkSize,
+        retriesPerChunk = it.retriesPerChunk,
+        optOut = it.optOut,
+        uploadJob = null,
+        successFlow = null,
+        progressFlow = null,
+        errorFlow = null,
+      )
   }
 }
 
@@ -149,6 +152,8 @@ private data class UploadEntry(
   val bytesSent: Long,
 ) {
   fun toJson(): JSONObject {
+    Log.d("NOURL", "Writing URL $url")
+    Log.d("NOURL", "bytes $bytesSent")
     return JSONObject().apply {
       put("file", file.absolutePath)
       put("data", JSONObject().apply {


### PR DESCRIPTION
Writing all progress updates can result in the real progress being overwritten during init after process shutdown. Without this, resumed uploads will simply fail due to the content-range header being mangled in a number of different luck-based ways.