### PR TITLE
doc: Finish out the public KDoc 

### DIFF
--- a/library/src/main/java/com/mux/video/upload/MuxUploadSdk.kt
+++ b/library/src/main/java/com/mux/video/upload/MuxUploadSdk.kt
@@ -11,13 +11,16 @@ import okhttp3.logging.HttpLoggingInterceptor
 import java.util.concurrent.TimeUnit
 
 /**
- * Uploads videos to Mux Video.
+ * The Mux Android Upload SDK. Uploads files to Mux Video, resuming them after process death.
  *
- * TODO: This would be a good place to put usage
+ * To use, create your [Direct Upload](https://docs.mux.com/guides/video/upload-files-directly) server-side,
+ * then upload your file from your app using the [MuxUpload] class.
+ *
+ * Before starting any uploads, you must call [initialize] at least once
  */
 object MuxUploadSdk {
   /**
-   * The current version of this SDK. Release builds of this SDK follow semver (https://semver.org)
+   * The current version of the SDK. Release builds of this SDK follow semver (https://semver.org)
    */
   @Suppress("unused")
   const val VERSION = BuildConfig.LIB_VERSION
@@ -56,6 +59,9 @@ object MuxUploadSdk {
       .build()
   }
 
+  /**
+   * Initializes the SDK with the given Context. The Context instance isn't saved.
+   */
   @Suppress("unused") @JvmOverloads
   fun initialize(appContext: Context, resumeStoppedUploads: Boolean = true) {
     initializeUploadPersistence(appContext)

--- a/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
@@ -17,10 +17,11 @@ object MuxUploadManager {
   private val logger get() = MuxUploadSdk.logger
 
   /**
-   * Finds an in-progress or paused upload and returns an object to track it, if it was
+   * Finds an in-progress, paused, or failed upload and returns a [MuxUpload] to track it, if it was
    * in progress
    */
   @Suppress("unused")
+  @MainThread
   fun findUploadByFile(videoFile: File): MuxUpload? =
     uploadsByFilename[videoFile.absolutePath]?.let { MuxUpload.create(it) }
 
@@ -30,12 +31,14 @@ object MuxUploadManager {
    * will continue in parallel if they're auto-managed (see [MuxUpload.Builder.manageUploadTask])
    */
   @Suppress("unused")
+  @MainThread
   fun allUploadJobs(): List<MuxUpload> = uploadsByFilename.values.map { MuxUpload.create(it) }
 
   /**
    * Resumes any upload jobs that were prematurely stopped due to failures or process death.
    * The jobs will all be resumed where they left off. Any jobs resumed this way will be returned
    */
+  @MainThread
   fun resumeAllCachedJobs(): List<MuxUpload> {
     return readAllCachedUploads()
       .onEach { uploadInfo -> startJob(uploadInfo, restart = false) }

--- a/library/src/main/java/com/mux/video/upload/api/UploadEventListener.kt
+++ b/library/src/main/java/com/mux/video/upload/api/UploadEventListener.kt
@@ -4,5 +4,8 @@ package com.mux.video.upload.api
  * Listens for events from the Mux Upload SDK
  */
 fun interface UploadEventListener<EventType> {
+  /**
+   * Called when an event is generated
+   */
   fun onEvent(event: EventType)
 }

--- a/library/src/main/java/com/mux/video/upload/internal/UploadMetrics.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadMetrics.kt
@@ -16,7 +16,8 @@ import java.util.*
 
 internal class UploadMetrics private constructor() {
 
-  suspend fun reportUpload(
+  @JvmSynthetic
+  internal suspend fun reportUpload(
     startTimeMillis: Long,
     endTimeMillis: Long,
     uploadInfo: UploadInfo

--- a/library/src/main/java/com/mux/video/upload/internal/network/CountingRequestBody.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/network/CountingRequestBody.kt
@@ -4,6 +4,7 @@ import okhttp3.MediaType
 import okhttp3.RequestBody
 import okio.BufferedSink
 
+@JvmSynthetic
 internal fun ByteArray.asCountingRequestBody(
   mediaType: MediaType?,
   contentLength: Long,
@@ -15,6 +16,7 @@ internal fun ByteArray.asCountingRequestBody(
   callback = callback
 )
 
+@JvmSynthetic
 internal fun ByteArray.asCountingRequestBody(
   mediaType: MediaType?,
   contentLength: Long,


### PR DESCRIPTION
This is in preparation for uploading the docs to our devdocs site, and with this PR all our notable public symbols should be doc'd

There's also some non-functional java interop: Some internal symbols were also hidden from Java by marking them synthetic.