### PR TITLE
Fix crash + subsequent upload error post-transcode

### DIFF
--- a/app/src/main/java/com/mux/video/vod/demo/backend/ImaginaryBackend.kt
+++ b/app/src/main/java/com/mux/video/vod/demo/backend/ImaginaryBackend.kt
@@ -56,8 +56,8 @@ object ImaginaryBackend {
   // note: You shouldn't do basic auth with hard-coded keys in a real app
   private fun basicCredential(): String = Credentials.basic(ACCESS_TOKEN_ID, ACCESS_TOKEN_SECRET)
 
-  private const val ACCESS_TOKEN_ID = "ac7b98b5-272e-46a3-98e0-418ae8458396"
-  private const val ACCESS_TOKEN_SECRET = "ePLLQcURa1iwLUnGqSt6aw8IN6mdaZms5zNl8/N3Ao0TOQ8JO1fzpDCmGGWYPTMc0ZY//fQ1ung"
+  private const val ACCESS_TOKEN_ID = "YOUR TOKEN ID HERE"
+  private const val ACCESS_TOKEN_SECRET = "YOUR TOKEN SECRET HERE"
 }
 
 private interface ImaginaryWebapp {

--- a/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
@@ -4,7 +4,6 @@ import android.net.Uri
 import androidx.annotation.MainThread
 import com.mux.video.upload.MuxUploadSdk
 import com.mux.video.upload.api.MuxUpload.Builder
-import com.mux.video.upload.internal.TranscoderContext
 import com.mux.video.upload.internal.UploadInfo
 import com.mux.video.upload.internal.update
 import kotlinx.coroutines.*
@@ -38,7 +37,7 @@ class MuxUpload private constructor(
   /**
    * File containing the video to be uploaded
    */
-  val videoFile: File get() = uploadInfo.file
+  val videoFile: File get() = uploadInfo.inputFile
 
   /**
    * The current state of the upload. To be notified of state updates, you can use
@@ -113,7 +112,7 @@ class MuxUpload private constructor(
       /*uploadInfo =*/ MuxUploadSdk.uploadJobFactory().createUploadJob(uploadInfo, coroutineScope)
     }
 
-    logger.i("MuxUpload", "started upload: ${uploadInfo.file}")
+    logger.i("MuxUpload", "started upload: ${uploadInfo.inputFile}")
     maybeObserveUpload(uploadInfo)
   }
 
@@ -301,8 +300,7 @@ class MuxUpload private constructor(
     private var uploadInfo: UploadInfo = UploadInfo(
       // Default values
       remoteUri = uploadUri,
-      file = videoFile,
-      standardizedFilePath = "",
+      inputFile = videoFile,
       chunkSize = 8 * 1024 * 1024, // GCP recommends at least 8M chunk size
       retriesPerChunk = 3,
       optOut = false,

--- a/library/src/main/java/com/mux/video/upload/internal/TranscoderContext.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/TranscoderContext.kt
@@ -104,7 +104,7 @@ class TranscoderContext internal constructor(
         var result:ArrayList<MediaCodecInfo> = ArrayList<MediaCodecInfo>();
         for(codecInfo in list.codecInfos) {
             Log.i("CodecInfo", codecInfo.name)
-            if(codecInfo.name.contains(mimeType) && codecInfo.isEncoder && codecInfo.isHardwareAcceleratedCompat()) {
+            if(codecInfo.name.contains(mimeType) && codecInfo.isEncoder && codecInfo.isHardwareAcceleratedCompat) {
                 result.add(codecInfo);
             }
         }

--- a/library/src/main/java/com/mux/video/upload/internal/TranscoderContext.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/TranscoderContext.kt
@@ -314,11 +314,14 @@ internal class TranscoderContext private constructor(
             muxer!!.stop()
             muxer!!.release()
             fileTranscoded = true;
+
+            logger.i("Muxer", "Transcoding duration time: $duration")
+            logger.i("Muxer", "Original file size: ${uploadInfo.inputFile.length()}")
+            logger.i("Muxer", "Transcoded file size: ${uploadInfo.standardizedFile?.length()}")
         } catch (ex:Exception) {
           // todo em - we might be able to slide by with a success as long as stop() completes
-          logger.e(LOG_TAG, "Couldn't stop the MediaMuxer", ex)
+          logger.e(LOG_TAG, "Couldn't stop the MediaMuxer!", ex)
         }
-        logger.i("Muxer", "Transcoding duration time: $duration")
 
         return uploadInfo
     }

--- a/library/src/main/java/com/mux/video/upload/internal/TranscoderContext.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/TranscoderContext.kt
@@ -16,7 +16,7 @@ import kotlin.experimental.and
 
 
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-class TranscoderContext internal constructor(
+internal class TranscoderContext private constructor(
     private var uploadInfo: UploadInfo,
     private val appContext: Context
 ) {
@@ -73,6 +73,13 @@ class TranscoderContext internal constructor(
     private var audioEncoder:MediaCodec? = null
     public var  fileTranscoded = false
     private var configured = false
+
+    companion object {
+      @JvmSynthetic
+      internal fun create(uploadInfo: UploadInfo, appContext: Context): TranscoderContext {
+        return TranscoderContext(uploadInfo, appContext)
+      }
+    }
 
     init {
         val cacheDir = File(appContext.cacheDir, "mux-upload")

--- a/library/src/main/java/com/mux/video/upload/internal/TranscoderContext.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/TranscoderContext.kt
@@ -5,7 +5,6 @@ import android.media.*
 import android.media.MediaCodec.BufferInfo
 import android.media.MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420SemiPlanar
 import android.os.Build
-import android.os.Environment
 import android.util.Log
 import androidx.annotation.RequiresApi
 import io.github.crow_misia.libyuv.FilterMode
@@ -86,11 +85,11 @@ class TranscoderContext internal constructor(
 //        val testFile = File(directory, "output.mp4")
 //        val output = testFile.outputStream()
         muxer = MediaMuxer(destFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
-        uploadInfo = uploadInfo.update(standardizedFilePath = destFile.absolutePath)
+        uploadInfo = uploadInfo.update(standardizedFile = destFile)
 //        muxer = MediaMuxer(testFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
 
         try {
-            extractor.setDataSource(uploadInfo.file.absolutePath)
+            extractor.setDataSource(uploadInfo.inputFile.absolutePath)
             checkIfTranscodingIsNeeded()
             configureDecoders()
             configured = true
@@ -115,7 +114,6 @@ class TranscoderContext internal constructor(
         var shouldStandardize: Boolean = false
         for (i in 0 until extractor.trackCount) {
             val format = extractor.getTrackFormat(i)
-            uploadInfo = uploadInfo.update(inputFileFormat = format.getString("file-format"))
             val mime = format.getString(MediaFormat.KEY_MIME)
             var inputDuration:Long = -1;
             if (mime?.lowercase()?.contains("video") == true) {
@@ -145,7 +143,7 @@ class TranscoderContext internal constructor(
                 inputBitrate = format.getIntegerCompat(MediaFormat.KEY_BIT_RATE, -1)
                 inputDuration = format.getLongCompat(MediaFormat.KEY_DURATION, -1)
                 if (inputBitrate == -1 && inputDuration != -1L) {
-                    inputBitrate = ((uploadInfo.file.length() * 8) / (inputDuration / 1000000)).toInt()
+                    inputBitrate = ((uploadInfo.inputFile.length() * 8) / (inputDuration / 1000000)).toInt()
                 }
                 if (inputBitrate > MAX_ALLOWED_BITRATE) {
                     shouldStandardize = true

--- a/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
@@ -17,11 +17,11 @@ import java.io.File
  * Job and Flows populated
  */
 internal data class UploadInfo(
-  @JvmSynthetic internal var shouldStandardize: Boolean = false,
-  @JvmSynthetic internal var inputFileFormat: String? = "",
+  @JvmSynthetic internal val shouldStandardize: Boolean = false,
+  @JvmSynthetic internal val inputFileFormat: String? = "",
   @JvmSynthetic internal val remoteUri: Uri,
   @JvmSynthetic internal var file: File,
-  @JvmSynthetic internal var standardizedFilePath: String? = "",
+  @JvmSynthetic internal val standardizedFilePath: String? = "",
   @JvmSynthetic internal val chunkSize: Int,
   @JvmSynthetic internal val retriesPerChunk: Int,
   @JvmSynthetic internal val optOut: Boolean,

--- a/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
@@ -18,10 +18,9 @@ import java.io.File
  */
 internal data class UploadInfo(
   @JvmSynthetic internal val shouldStandardize: Boolean = false,
-  @JvmSynthetic internal val inputFileFormat: String? = "",
   @JvmSynthetic internal val remoteUri: Uri,
-  @JvmSynthetic internal var file: File,
-  @JvmSynthetic internal val standardizedFilePath: String? = "",
+  @JvmSynthetic internal val inputFile: File,
+  @JvmSynthetic internal val standardizedFile: File? = null,
   @JvmSynthetic internal val chunkSize: Int,
   @JvmSynthetic internal val retriesPerChunk: Int,
   @JvmSynthetic internal val optOut: Boolean,
@@ -30,6 +29,7 @@ internal data class UploadInfo(
   @JvmSynthetic internal val progressFlow: SharedFlow<MuxUpload.Progress>?,
   @JvmSynthetic internal val errorFlow: SharedFlow<Exception>?,
 ) {
+  val fileForUpload: File get() = standardizedFile ?: inputFile
   fun isRunning(): Boolean = uploadJob?.isActive ?: false
 }
 
@@ -40,10 +40,9 @@ internal data class UploadInfo(
 @JvmSynthetic
 internal fun UploadInfo.update(
   shouldStandardize: Boolean = this.shouldStandardize,
-  inputFileFormat: String? = this.inputFileFormat,
   remoteUri: Uri = this.remoteUri,
-  file: File = this.file,
-  standardizedFilePath: String? = this.standardizedFilePath,
+  file: File = this.inputFile,
+  standardizedFile: File? = this.standardizedFile,
   chunkSize: Int = this.chunkSize,
   retriesPerChunk: Int = this.retriesPerChunk,
   optOut: Boolean = this.optOut,
@@ -53,10 +52,9 @@ internal fun UploadInfo.update(
   errorFlow: SharedFlow<Exception>? = this.errorFlow,
 ) = UploadInfo(
   shouldStandardize,
-  inputFileFormat,
   remoteUri,
   file,
-  standardizedFilePath,
+  standardizedFile,
   chunkSize,
   retriesPerChunk,
   optOut,

--- a/library/src/main/java/com/mux/video/upload/internal/UploadJobFactory.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadJobFactory.kt
@@ -71,7 +71,7 @@ internal class UploadJobFactory private constructor(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
           // See if the file need to be converted to a standard input
           val tcx = TranscoderContext(uploadInfo, MuxUploadManager.appContext!!)
-          tcx.start()
+          tcx.process()
           if (tcx.fileTranscoded) {
             // delete uploadInfo.file and use uploadInfo.
             uploadInfo.file.delete()

--- a/library/src/main/java/com/mux/video/upload/internal/UploadJobFactory.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadJobFactory.kt
@@ -74,7 +74,7 @@ internal class UploadJobFactory private constructor(
       try {
         // See if the file need to be converted to a standard input.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-          val tcx = TranscoderContext(internalUploadInfo, MuxUploadManager.appContext!!)
+          val tcx = TranscoderContext.create(internalUploadInfo, MuxUploadManager.appContext!!)
           internalUploadInfo = tcx.process()
           if (tcx.fileTranscoded) {
             fileStream = withContext(Dispatchers.IO) {

--- a/library/src/main/java/com/mux/video/upload/internal/UploadJobFactory.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadJobFactory.kt
@@ -1,5 +1,6 @@
 package com.mux.video.upload.internal
 
+import android.os.Build
 import android.util.Log
 import com.mux.video.upload.BuildConfig
 import com.mux.video.upload.MuxUploadSdk
@@ -67,15 +68,17 @@ internal class UploadJobFactory private constructor(
     val uploadJob = outerScope.async {
       val startTime = System.currentTimeMillis()
       try {
-        // See if the file need to be converted to a standard input
-        val tcx = TranscoderContext(uploadInfo, MuxUploadManager.appContext!!)
-        tcx.start()
-        if (tcx.fileTranscoded) {
-          // delete uploadInfo.file and use uploadInfo.
-          uploadInfo.file.delete()
-          uploadInfo.file = File(uploadInfo.standardizedFilePath)
-          fileStream = BufferedInputStream(FileInputStream(uploadInfo.file))
-          fileSize = uploadInfo.file.length()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+          // See if the file need to be converted to a standard input
+          val tcx = TranscoderContext(uploadInfo, MuxUploadManager.appContext!!)
+          tcx.start()
+          if (tcx.fileTranscoded) {
+            // delete uploadInfo.file and use uploadInfo.
+            uploadInfo.file.delete()
+            uploadInfo.file = File(uploadInfo.standardizedFilePath)
+            fileStream = BufferedInputStream(FileInputStream(uploadInfo.file))
+            fileSize = uploadInfo.file.length()
+          }
         }
 
         var totalBytesSent: Long = getAlreadyTransferredBytes(uploadInfo)

--- a/library/src/main/java/com/mux/video/upload/internal/UploadMetrics.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadMetrics.kt
@@ -25,7 +25,7 @@ internal class UploadMetrics private constructor() {
     val videoDuration = withContext(Dispatchers.IO) {
       try {
         MediaMetadataRetriever().use { retriever ->
-          retriever.setDataSource(uploadInfo.file.absolutePath)
+          retriever.setDataSource(uploadInfo.inputFile.absolutePath)
           retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toInt()
         }
       } catch (e: Exception) {
@@ -37,7 +37,7 @@ internal class UploadMetrics private constructor() {
     val eventJson = UploadEvent(
       startTimeMillis = startTimeMillis,
       endTimeMillis = endTimeMillis,
-      fileSize = uploadInfo.file.length(),
+      fileSize = uploadInfo.inputFile.length(),
       videoDuration = videoDuration ?: 0,
       sdkVersion = BuildConfig.LIB_VERSION,
       osName = "Android",

--- a/library/src/main/java/com/mux/video/upload/internal/UploadPersistence.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadPersistence.kt
@@ -3,7 +3,6 @@ package com.mux.video.upload.internal
 import android.content.Context
 import android.content.SharedPreferences
 import android.net.Uri
-import android.util.Log
 import com.mux.video.upload.api.MuxUpload
 import org.json.JSONArray
 import org.json.JSONObject
@@ -19,7 +18,7 @@ internal fun initializeUploadPersistence(appContext: Context) {
 internal fun writeUploadState(uploadInfo: UploadInfo, state: MuxUpload.Progress) {
   UploadPersistence.write(
     UploadEntry(
-      file = uploadInfo.file,
+      file = uploadInfo.inputFile,
       url = uploadInfo.remoteUri.toString(),
       savedAtLocalMs = Date().time,
       state = if (uploadInfo.isRunning()) {
@@ -37,7 +36,7 @@ internal fun writeUploadState(uploadInfo: UploadInfo, state: MuxUpload.Progress)
 
 @JvmSynthetic
 internal fun readLastByteForFile(upload: UploadInfo): Long {
-  return UploadPersistence.readEntries()[upload.file.absolutePath]?.bytesSent ?: 0
+  return UploadPersistence.readEntries()[upload.inputFile.absolutePath]?.bytesSent ?: 0
 }
 
 @JvmSynthetic
@@ -52,7 +51,7 @@ internal fun readAllCachedUploads(): List<UploadInfo> {
     .map {
       UploadInfo(
         remoteUri = Uri.parse(it.url),
-        file =  it.file,
+        inputFile =  it.file,
         chunkSize = it.chunkSize,
         retriesPerChunk = it.retriesPerChunk,
         optOut = it.optOut,
@@ -91,7 +90,7 @@ private object UploadPersistence {
   fun removeForFile(upload: UploadInfo) {
     checkInitialized()
     val entries = readEntries()
-    entries -= upload.file.absolutePath
+    entries -= upload.inputFile.absolutePath
     writeEntries(entries)
   }
 

--- a/library/src/main/java/com/mux/video/upload/internal/Util.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/Util.kt
@@ -1,5 +1,8 @@
 package com.mux.video.upload.internal
 
+import android.media.MediaCodecInfo
+import android.media.MediaFormat
+import android.os.Build
 import android.os.Looper
 
 /**
@@ -12,5 +15,56 @@ import android.os.Looper
 internal fun assertMainThread() {
   if (Looper.myLooper()?.equals(Looper.getMainLooper()) != true) {
     throw IllegalStateException("This can only be called from the main thread")
+  }
+}
+
+/**
+ * Gets an Integer from a [MediaFormat] with the given key. If the key is missing or null, returns
+ * a default value
+ *
+ * On API < Q, this method must branch to safely check for the key
+ */
+@JvmSynthetic
+internal fun MediaFormat.getIntegerCompat(key: String, default: Int): Int {
+  return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+    getInteger(key, default)
+    // Before Q, we have to check for the key manually. Not checking can result in an exception
+  } else if (containsKey(key)) {
+    getInteger(key)
+  } else {
+    default
+  }
+}
+
+/**
+ * Gets a Long from a [MediaFormat] with the given key. If the key is missing or null, returns
+ * a default value
+ *
+ * On API < Q, this method must branch to safely check for the key
+ */
+@JvmSynthetic
+internal fun MediaFormat.getLongCompat(key: String, default: Long): Long {
+  return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+    getLong(key, default)
+  } else if (containsKey(key)) {
+    getLong(key)
+  } else {
+    default
+  }
+}
+
+/**
+ * Returns true if the codec described is hardware-accelerated, or else it returns false.
+ *
+ * On API < Q, this information is not available so this method returns true. This behavior could
+ * potentially be expanded in the future
+ */
+@JvmSynthetic
+internal fun MediaCodecInfo.isHardwareAcceleratedCompat(): Boolean {
+  return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+    isHardwareAccelerated
+  } else {
+    // On < Q, we can't tell. Return true because there's no point in filtering codecs in this case
+    true
   }
 }

--- a/library/src/main/java/com/mux/video/upload/internal/Util.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/Util.kt
@@ -59,8 +59,7 @@ internal fun MediaFormat.getLongCompat(key: String, default: Long): Long {
  * On API < Q, this information is not available so this method returns true. This behavior could
  * potentially be expanded in the future
  */
-@JvmSynthetic
-internal fun MediaCodecInfo.isHardwareAcceleratedCompat(): Boolean {
+internal val MediaCodecInfo.isHardwareAcceleratedCompat: Boolean get() {
   return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
     isHardwareAccelerated
   } else {

--- a/library/src/test/java/com/mux/video/upload/internal/UploadPersistenceTests.kt
+++ b/library/src/test/java/com/mux/video/upload/internal/UploadPersistenceTests.kt
@@ -42,12 +42,12 @@ class UploadPersistenceTests : AbsRobolectricTest() {
       1,
       uploadsOut.size
     )
-    val uploadOutA = uploadsOut.find { it.file.absolutePath == uploadInfoInA.file.absolutePath }
+    val uploadOutA = uploadsOut.find { it.inputFile.absolutePath == uploadInfoInA.inputFile.absolutePath }
     assertNull(
       "file A should NOT be in the output",
       uploadOutA
     )
-    val uploadOutB = uploadsOut.find { it.file.absolutePath == uploadInfoInB.file.absolutePath }
+    val uploadOutB = uploadsOut.find { it.inputFile.absolutePath == uploadInfoInB.inputFile.absolutePath }
     assertNotNull(
       "upload B should be in the output",
       uploadOutB,
@@ -81,7 +81,7 @@ class UploadPersistenceTests : AbsRobolectricTest() {
       2,
       uploadsOut.size
     )
-    val uploadOutA = uploadsOut.find { it.file.absolutePath == uploadInfoInA.file.absolutePath }
+    val uploadOutA = uploadsOut.find { it.inputFile.absolutePath == uploadInfoInA.inputFile.absolutePath }
     assertNotNull(
       "file A should be in the output",
       uploadOutA
@@ -129,7 +129,7 @@ class UploadPersistenceTests : AbsRobolectricTest() {
   }
 
   private fun uploadInfo(name: String = "a/file") = UploadInfo(
-    file = File(name).absoluteFile,
+    inputFile = File(name).absoluteFile,
     remoteUri = Uri.parse("https://www.mux.com/$name"),
     chunkSize = 2,
     retriesPerChunk = 3,


### PR DESCRIPTION
Fixes:

* Fix crashes on older Android versions. Standardization should work on Android Lollipop and higher. This should be more than fine for now. HW acceleration is leveraged explicitly when possible
* Fix crash when done transcoding: `UploadInfo` isn't meant to be mutable, so after working the `TranscoderContext` will return a new one with the updated data.
* Remove `UploadInfo.inputFileFormat`. This can be reverted if it is needed
* Fix uploads failing due to pre-transcode file size being used for some chunk math