### PR TITLE
feat: Add API for listening-to and retrieving the status of an upload

### DIFF
--- a/app/src/main/java/com/mux/video/vod/demo/upload/UploadListAdapter.kt
+++ b/app/src/main/java/com/mux/video/vod/demo/upload/UploadListAdapter.kt
@@ -23,15 +23,15 @@ class UploadListAdapter(
 
   override fun onBindViewHolder(holder: MediaStoreVideoViewHolder, position: Int) {
     val listItem = items[position]
-    val elapsedTime = listItem.currentState.updatedTime - listItem.currentState.startTime
-    val bytesPerMs = listItem.currentState.bytesUploaded / elapsedTime.toDouble()
-    val stateMsg = if (listItem.currentState.bytesUploaded >= listItem.currentState.totalBytes) {
+    val elapsedTime = listItem.currentProgress.updatedTime - listItem.currentProgress.startTime
+    val bytesPerMs = listItem.currentProgress.bytesUploaded / elapsedTime.toDouble()
+    val stateMsg = if (listItem.currentProgress.bytesUploaded >= listItem.currentProgress.totalBytes) {
       "done"
     } else {
       "not done"
     }
     val progressPercent =
-      (listItem.currentState.bytesUploaded / listItem.currentState.totalBytes.toDouble()) * 100.0
+      (listItem.currentProgress.bytesUploaded / listItem.currentProgress.totalBytes.toDouble()) * 100.0
     val df = DecimalFormat("#.00")
     val formattedRate = df.format(bytesPerMs)
 
@@ -40,7 +40,7 @@ class UploadListAdapter(
     holder.viewBinding.mediastoreVideoProgress.max = 100
     holder.viewBinding.mediastoreVideoFilename.text = listItem.videoFile.absolutePath
     holder.viewBinding.mediastoreVideoDate.text =
-      "${listItem.currentState.bytesUploaded} bytes in ${elapsedTime / 1000F} s elapsed "
+      "${listItem.currentProgress.bytesUploaded} bytes in ${elapsedTime / 1000F} s elapsed "
     holder.viewBinding.mediastoreVideoFilesize.text = "${formattedRate} KBytes/s"
 
     if (listItem.isRunning) {

--- a/app/src/main/java/com/mux/video/vod/demo/upload/screen/UploadListScreen.kt
+++ b/app/src/main/java/com/mux/video/vod/demo/upload/screen/UploadListScreen.kt
@@ -182,7 +182,7 @@ private fun ListItemContent(upload: MuxUpload) {
       ErrorOverlay(modifier = Modifier.fillMaxSize())
     } else if (upload.isRunning) {
       ProgressOverlay(
-        upload.currentState,
+        upload.currentProgress,
         modifier = Modifier
           .align(Alignment.BottomStart)
           .fillMaxWidth()

--- a/library/src/main/java/com/mux/video/upload/MuxUploadSdk.kt
+++ b/library/src/main/java/com/mux/video/upload/MuxUploadSdk.kt
@@ -70,7 +70,7 @@ object MuxUploadSdk {
     initializeUploadPersistence(appContext)
     UploadMetrics.initialize(appContext)
     if (resumeStoppedUploads) {
-      val upl = MuxUploadManager.resumeAllCachedJobs()
+      MuxUploadManager.resumeAllCachedJobs()
     }
   }
 

--- a/library/src/main/java/com/mux/video/upload/api/InputStatus.kt
+++ b/library/src/main/java/com/mux/video/upload/api/InputStatus.kt
@@ -62,8 +62,9 @@ sealed class InputStatus {
    * The upload has failed. Part of the file may have already been uploaded, and this upload can be
    * resumed from this state via [MuxUpload.start]
    */
-  class UPLOAD_FAILED(val exception: Exception): InputStatus() {
+  class UPLOAD_FAILED(val exception: Exception, val progress: MuxUpload.Progress): InputStatus() {
     override fun getError(): Exception = exception
+    override fun getProgress(): MuxUpload.Progress = progress
   }
 
   /**

--- a/library/src/main/java/com/mux/video/upload/api/InputStatus.kt
+++ b/library/src/main/java/com/mux/video/upload/api/InputStatus.kt
@@ -1,0 +1,69 @@
+package com.mux.video.upload.api
+
+/**
+ * The current state of the upload. Uploads are first examined, potentially processed, then uploaded
+ * to Mux Video
+ */
+sealed class InputStatus {
+
+  // Java Compatibility
+
+  /**
+   * The progress, in bytes, of the upload. If the file isn't uploading yet, this will be null.
+   *
+   * This is provided for java callers. Kotlin callers can use [InputStatus] as a sealed class as
+   * normal
+   */
+  open fun getProgress(): MuxUpload.Progress? = null
+
+  /**
+   * If this upload failed, returns the error that caused the failure
+   *
+   * This is provided for java callers. Kotlin callers can use [InputStatus] as a sealed class as
+   * normal
+   */
+  open fun getError(): Exception? = null
+
+  // Subclasses
+
+  /**
+   * This upload hos not been started. It is ready to start by calling [MuxUpload.start]
+   */
+  object READY : InputStatus()
+
+  /**
+   * This upload has been started via [MuxUpload.start] but has not yet started processing anything
+   */
+  object STARTED: InputStatus()
+
+  /**
+   * This upload is being prepared. If standardization is required, it is done during this step
+   *
+   * @see MuxUpload.Builder.standardizationRequested
+   */
+  object PREPARING: InputStatus()
+
+  /**
+   * The upload is currently being sent to Mux Video. The progress is available
+   */
+  class UPLOADING(val progress: MuxUpload.Progress): InputStatus() {
+    override fun getProgress(): MuxUpload.Progress = progress
+  }
+
+  /**
+   * The upload is currently paused. Part of the video file may have already been uploaded to Mux
+   * Video, but no data is currently being sent
+   */
+  class UPLOAD_PAUSED(val progress: MuxUpload.Progress): InputStatus() {
+    override fun getProgress(): MuxUpload.Progress = progress
+  }
+
+  /**
+   * The upload has failed. Part of the file may have already been uploaded, and this upload can be
+   * resumed from this state via [MuxUpload.start]
+   */
+  class UPLOAD_FAILED(val exception: Exception): InputStatus() {
+    override fun getError(): Exception = exception
+  }
+
+}

--- a/library/src/main/java/com/mux/video/upload/api/InputStatus.kt
+++ b/library/src/main/java/com/mux/video/upload/api/InputStatus.kt
@@ -66,4 +66,10 @@ sealed class InputStatus {
     override fun getError(): Exception = exception
   }
 
+  /**
+   * The upload succeeded. The file has been uploaded to Mux Video and will be processed shortly
+   */
+  class UPLOAD_SUCCESS(val progress: MuxUpload.Progress): InputStatus() {
+    override fun getProgress(): MuxUpload.Progress = progress
+  }
 }

--- a/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
@@ -140,11 +140,10 @@ class MuxUpload private constructor(
   @Throws
   @Suppress("unused")
   @JvmSynthetic
-  suspend fun awaitSuccess(): Result<Progress> {
-    // TODO: Return Result<InputStatus>? Only worthwhile if awaitSuccess() returns for like pause() etc also
+  suspend fun awaitSuccess(): Result<UploadStatus> {
     val status = uploadStatus // base our logic on a stable snapshot of the status
     return if (status is UploadStatus.UploadSuccess) {
-      Result.success(status.uploadProgress) // If we succeeded already, don't start again
+      Result.success(status) // If we succeeded already, don't start again
     } else {
       coroutineScope {
         startInner(coroutineScope = this)

--- a/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
@@ -135,10 +135,7 @@ class MuxUpload private constructor(
     } else {
       coroutineScope {
         startInner(coroutineScope = this)
-        uploadInfo.uploadJob?.let { job ->
-          val result = job.await()
-          result
-        } ?: Result.failure(Exception("Upload failed to start"))
+        uploadInfo.uploadJob?.await() ?: Result.failure(Exception("Upload failed to start"))
       }
     }
   }

--- a/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
@@ -33,7 +33,7 @@ import java.io.File
 class MuxUpload private constructor(
   private var uploadInfo: UploadInfo,
   private val autoManage: Boolean = true,
-  initialStatus: UploadStatus = UploadStatus.READY
+  initialStatus: UploadStatus = UploadStatus.Ready
 ) {
 
   /**
@@ -84,7 +84,7 @@ class MuxUpload private constructor(
   private var progressListener: UploadEventListener<Progress>? = null
   private var statusListener: UploadEventListener<UploadStatus>? = null
   private var observerJob: Job? = null
-  private var currentStatus: UploadStatus = UploadStatus.READY
+  private var currentStatus: UploadStatus = UploadStatus.Ready
   @Deprecated(message = "delete before PR is merged, (or keep it and remove this line)")
   private val lastKnownProgress: Progress? get() = currentStatus.getProgress()
 
@@ -149,7 +149,7 @@ class MuxUpload private constructor(
   suspend fun awaitSuccess(): Result<Progress> {
     // TODO: Return Result<InputStatus>? Only worthwhile if awaitSuccess() returns for like pause() etc also
     val status = uploadStatus // base our logic on a stable snapshot of the status
-    return if (status is UploadStatus.UPLOAD_SUCCESS) {
+    return if (status is UploadStatus.UploadSuccess) {
       Result.success(status.uploadProgress) // If we succeeded already, don't start again
     } else {
       coroutineScope {
@@ -258,13 +258,13 @@ class MuxUpload private constructor(
 
             // Notify the old listeners
             when (status) {
-              is UploadStatus.UPLOADING -> { updateProgress(status.uploadProgress) }
-              is UploadStatus.UPLOAD_PAUSED -> { updateProgress(status.uploadProgress) }
-              is UploadStatus.UPLOAD_SUCCESS -> {
+              is UploadStatus.Uploading -> { updateProgress(status.uploadProgress) }
+              is UploadStatus.UploadPaused -> { updateProgress(status.uploadProgress) }
+              is UploadStatus.UploadSuccess -> {
                 updateProgress(status.uploadProgress)
                 resultListener?.onEvent(Result.success(status.uploadProgress))
               }
-              is UploadStatus.UPLOAD_FAILED -> {
+              is UploadStatus.UploadFailed -> {
                 progressListener?.onEvent(status.uploadProgress) // Make sure we're most up-to-date
                 if (status.exception !is CancellationException) {
                   _error = status.exception
@@ -412,7 +412,7 @@ class MuxUpload private constructor(
      * [MuxUploadManager]
      */
     @JvmSynthetic
-    internal fun create(uploadInfo: UploadInfo, initialStatus: UploadStatus = UploadStatus.READY)
+    internal fun create(uploadInfo: UploadInfo, initialStatus: UploadStatus = UploadStatus.Ready)
       = MuxUpload(uploadInfo = uploadInfo, initialStatus = initialStatus)
   }
 }

--- a/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
@@ -176,7 +176,7 @@ object MuxUploadManager {
       upload.statusFlow?.let { statusFlow ->
         launch {
           statusFlow
-            .filter { it is UploadStatus.UPLOAD_SUCCESS }
+            .filter { it is UploadStatus.UploadSuccess }
             .collect { jobFinished(upload) }
         }
       }

--- a/library/src/main/java/com/mux/video/upload/api/UploadStatus.kt
+++ b/library/src/main/java/com/mux/video/upload/api/UploadStatus.kt
@@ -29,24 +29,24 @@ sealed class UploadStatus {
   /**
    * This upload hos not been started. It is ready to start by calling [MuxUpload.start]
    */
-  object READY : UploadStatus()
+  object Ready: UploadStatus()
 
   /**
    * This upload has been started via [MuxUpload.start] but has not yet started processing anything
    */
-  object STARTED: UploadStatus()
+  object Started: UploadStatus()
 
   /**
    * This upload is being prepared. If standardization is required, it is done during this step
    *
    * @see MuxUpload.Builder.standardizationRequested
    */
-  object PREPARING: UploadStatus()
+  object Preparing: UploadStatus()
 
   /**
    * The upload is currently being sent to Mux Video. The progress is available
    */
-  class UPLOADING(val uploadProgress: MuxUpload.Progress): UploadStatus() {
+  class Uploading(val uploadProgress: MuxUpload.Progress): UploadStatus() {
     override fun getProgress(): MuxUpload.Progress = uploadProgress
   }
 
@@ -54,7 +54,7 @@ sealed class UploadStatus {
    * The upload is currently paused. Part of the video file may have already been uploaded to Mux
    * Video, but no data is currently being sent
    */
-  class UPLOAD_PAUSED(val uploadProgress: MuxUpload.Progress): UploadStatus() {
+  class UploadPaused(val uploadProgress: MuxUpload.Progress): UploadStatus() {
     override fun getProgress(): MuxUpload.Progress = uploadProgress
   }
 
@@ -62,7 +62,7 @@ sealed class UploadStatus {
    * The upload has failed. Part of the file may have already been uploaded, and this upload can be
    * resumed from this state via [MuxUpload.start]
    */
-  class UPLOAD_FAILED(val exception: Exception, val uploadProgress: MuxUpload.Progress): UploadStatus() {
+  class UploadFailed(val exception: Exception, val uploadProgress: MuxUpload.Progress): UploadStatus() {
     override fun getError(): Exception = exception
     override fun getProgress(): MuxUpload.Progress = uploadProgress
   }
@@ -70,7 +70,7 @@ sealed class UploadStatus {
   /**
    * The upload succeeded. The file has been uploaded to Mux Video and will be processed shortly
    */
-  class UPLOAD_SUCCESS(val uploadProgress: MuxUpload.Progress): UploadStatus() {
+  class UploadSuccess(val uploadProgress: MuxUpload.Progress): UploadStatus() {
     override fun getProgress(): MuxUpload.Progress = uploadProgress
   }
 }

--- a/library/src/main/java/com/mux/video/upload/api/UploadStatus.kt
+++ b/library/src/main/java/com/mux/video/upload/api/UploadStatus.kt
@@ -46,31 +46,31 @@ sealed class UploadStatus {
   /**
    * The upload is currently being sent to Mux Video. The progress is available
    */
-  class UPLOADING(val progress: MuxUpload.Progress): UploadStatus() {
-    override fun getProgress(): MuxUpload.Progress = progress
+  class UPLOADING(val uploadProgress: MuxUpload.Progress): UploadStatus() {
+    override fun getProgress(): MuxUpload.Progress = uploadProgress
   }
 
   /**
    * The upload is currently paused. Part of the video file may have already been uploaded to Mux
    * Video, but no data is currently being sent
    */
-  class UPLOAD_PAUSED(val progress: MuxUpload.Progress): UploadStatus() {
-    override fun getProgress(): MuxUpload.Progress = progress
+  class UPLOAD_PAUSED(val uploadProgress: MuxUpload.Progress): UploadStatus() {
+    override fun getProgress(): MuxUpload.Progress = uploadProgress
   }
 
   /**
    * The upload has failed. Part of the file may have already been uploaded, and this upload can be
    * resumed from this state via [MuxUpload.start]
    */
-  class UPLOAD_FAILED(val exception: Exception, val progress: MuxUpload.Progress): UploadStatus() {
+  class UPLOAD_FAILED(val exception: Exception, val uploadProgress: MuxUpload.Progress): UploadStatus() {
     override fun getError(): Exception = exception
-    override fun getProgress(): MuxUpload.Progress = progress
+    override fun getProgress(): MuxUpload.Progress = uploadProgress
   }
 
   /**
    * The upload succeeded. The file has been uploaded to Mux Video and will be processed shortly
    */
-  class UPLOAD_SUCCESS(val progress: MuxUpload.Progress): UploadStatus() {
-    override fun getProgress(): MuxUpload.Progress = progress
+  class UPLOAD_SUCCESS(val uploadProgress: MuxUpload.Progress): UploadStatus() {
+    override fun getProgress(): MuxUpload.Progress = uploadProgress
   }
 }

--- a/library/src/main/java/com/mux/video/upload/api/UploadStatus.kt
+++ b/library/src/main/java/com/mux/video/upload/api/UploadStatus.kt
@@ -2,16 +2,16 @@ package com.mux.video.upload.api
 
 /**
  * The current state of the upload. Uploads are first examined, potentially processed, then uploaded
- * to Mux Video
+ * to Mux Video.
  */
-sealed class InputStatus {
+sealed class UploadStatus {
 
   // Java Compatibility
 
   /**
    * The progress, in bytes, of the upload. If the file isn't uploading yet, this will be null.
    *
-   * This is provided for java callers. Kotlin callers can use [InputStatus] as a sealed class as
+   * This is provided for java callers. Kotlin callers can use [UploadStatus] as a sealed class as
    * normal
    */
   open fun getProgress(): MuxUpload.Progress? = null
@@ -19,7 +19,7 @@ sealed class InputStatus {
   /**
    * If this upload failed, returns the error that caused the failure
    *
-   * This is provided for java callers. Kotlin callers can use [InputStatus] as a sealed class as
+   * This is provided for java callers. Kotlin callers can use [UploadStatus] as a sealed class as
    * normal
    */
   open fun getError(): Exception? = null
@@ -29,24 +29,24 @@ sealed class InputStatus {
   /**
    * This upload hos not been started. It is ready to start by calling [MuxUpload.start]
    */
-  object READY : InputStatus()
+  object READY : UploadStatus()
 
   /**
    * This upload has been started via [MuxUpload.start] but has not yet started processing anything
    */
-  object STARTED: InputStatus()
+  object STARTED: UploadStatus()
 
   /**
    * This upload is being prepared. If standardization is required, it is done during this step
    *
    * @see MuxUpload.Builder.standardizationRequested
    */
-  object PREPARING: InputStatus()
+  object PREPARING: UploadStatus()
 
   /**
    * The upload is currently being sent to Mux Video. The progress is available
    */
-  class UPLOADING(val progress: MuxUpload.Progress): InputStatus() {
+  class UPLOADING(val progress: MuxUpload.Progress): UploadStatus() {
     override fun getProgress(): MuxUpload.Progress = progress
   }
 
@@ -54,7 +54,7 @@ sealed class InputStatus {
    * The upload is currently paused. Part of the video file may have already been uploaded to Mux
    * Video, but no data is currently being sent
    */
-  class UPLOAD_PAUSED(val progress: MuxUpload.Progress): InputStatus() {
+  class UPLOAD_PAUSED(val progress: MuxUpload.Progress): UploadStatus() {
     override fun getProgress(): MuxUpload.Progress = progress
   }
 
@@ -62,7 +62,7 @@ sealed class InputStatus {
    * The upload has failed. Part of the file may have already been uploaded, and this upload can be
    * resumed from this state via [MuxUpload.start]
    */
-  class UPLOAD_FAILED(val exception: Exception, val progress: MuxUpload.Progress): InputStatus() {
+  class UPLOAD_FAILED(val exception: Exception, val progress: MuxUpload.Progress): UploadStatus() {
     override fun getError(): Exception = exception
     override fun getProgress(): MuxUpload.Progress = progress
   }
@@ -70,7 +70,7 @@ sealed class InputStatus {
   /**
    * The upload succeeded. The file has been uploaded to Mux Video and will be processed shortly
    */
-  class UPLOAD_SUCCESS(val progress: MuxUpload.Progress): InputStatus() {
+  class UPLOAD_SUCCESS(val progress: MuxUpload.Progress): UploadStatus() {
     override fun getProgress(): MuxUpload.Progress = progress
   }
 }

--- a/library/src/main/java/com/mux/video/upload/internal/TranscoderContext.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/TranscoderContext.kt
@@ -299,7 +299,7 @@ internal class TranscoderContext private constructor(
         }
 
         logger.i(LOG_TAG, "Standardizing input")
-      configure()
+        configure()
         if (!configured) {
             logger.e(
               LOG_TAG,

--- a/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
@@ -1,8 +1,10 @@
 package com.mux.video.upload.internal
 
 import android.net.Uri
+import com.mux.video.upload.api.InputStatus
 import com.mux.video.upload.api.MuxUpload
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import java.io.File
 
@@ -25,9 +27,7 @@ internal data class UploadInfo(
   @JvmSynthetic internal val retriesPerChunk: Int,
   @JvmSynthetic internal val optOut: Boolean,
   @JvmSynthetic internal val uploadJob: Deferred<Result<MuxUpload.Progress>>?,
-  @JvmSynthetic internal val successFlow: SharedFlow<MuxUpload.Progress>?,
-  @JvmSynthetic internal val progressFlow: SharedFlow<MuxUpload.Progress>?,
-  @JvmSynthetic internal val errorFlow: SharedFlow<Exception>?,
+  @JvmSynthetic internal val statusFlow: Flow<InputStatus>?,
 ) {
   fun isRunning(): Boolean = uploadJob?.isActive ?: false
 }
@@ -46,9 +46,7 @@ internal fun UploadInfo.update(
   retriesPerChunk: Int = this.retriesPerChunk,
   optOut: Boolean = this.optOut,
   uploadJob: Deferred<Result<MuxUpload.Progress>>? = this.uploadJob,
-  successFlow: SharedFlow<MuxUpload.Progress>? = this.successFlow,
-  progressFlow: SharedFlow<MuxUpload.Progress>? = this.progressFlow,
-  errorFlow: SharedFlow<Exception>? = this.errorFlow,
+  statusFlow: Flow<InputStatus>?
 ) = UploadInfo(
   standardizationRequested,
   remoteUri,
@@ -58,7 +56,5 @@ internal fun UploadInfo.update(
   retriesPerChunk,
   optOut,
   uploadJob,
-  successFlow,
-  progressFlow,
-  errorFlow
+  statusFlow,
 )

--- a/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
@@ -25,7 +25,7 @@ internal data class UploadInfo(
   @JvmSynthetic internal val chunkSize: Int,
   @JvmSynthetic internal val retriesPerChunk: Int,
   @JvmSynthetic internal val optOut: Boolean,
-  @JvmSynthetic internal val uploadJob: Deferred<Result<MuxUpload.Progress>>?,
+  @JvmSynthetic internal val uploadJob: Deferred<Result<UploadStatus>>?,
   @JvmSynthetic internal val statusFlow: StateFlow<UploadStatus>?,
 ) {
   fun isRunning(): Boolean = uploadJob?.isActive ?: false
@@ -44,7 +44,7 @@ internal fun UploadInfo.update(
   chunkSize: Int = this.chunkSize,
   retriesPerChunk: Int = this.retriesPerChunk,
   optOut: Boolean = this.optOut,
-  uploadJob: Deferred<Result<MuxUpload.Progress>>? = this.uploadJob,
+  uploadJob: Deferred<Result<UploadStatus>>? = this.uploadJob,
   statusFlow: StateFlow<UploadStatus>? = this.statusFlow,
 ) = UploadInfo(
   standardizationRequested,

--- a/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
@@ -45,7 +45,7 @@ internal fun UploadInfo.update(
   retriesPerChunk: Int = this.retriesPerChunk,
   optOut: Boolean = this.optOut,
   uploadJob: Deferred<Result<MuxUpload.Progress>>? = this.uploadJob,
-  statusFlow: StateFlow<UploadStatus>?
+  statusFlow: StateFlow<UploadStatus>? = this.statusFlow,
 ) = UploadInfo(
   standardizationRequested,
   remoteUri,

--- a/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
@@ -1,11 +1,10 @@
 package com.mux.video.upload.internal
 
 import android.net.Uri
-import com.mux.video.upload.api.InputStatus
+import com.mux.video.upload.api.UploadStatus
 import com.mux.video.upload.api.MuxUpload
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import java.io.File
 
 /**
@@ -27,7 +26,7 @@ internal data class UploadInfo(
   @JvmSynthetic internal val retriesPerChunk: Int,
   @JvmSynthetic internal val optOut: Boolean,
   @JvmSynthetic internal val uploadJob: Deferred<Result<MuxUpload.Progress>>?,
-  @JvmSynthetic internal val statusFlow: Flow<InputStatus>?,
+  @JvmSynthetic internal val statusFlow: StateFlow<UploadStatus>?,
 ) {
   fun isRunning(): Boolean = uploadJob?.isActive ?: false
 }
@@ -46,7 +45,7 @@ internal fun UploadInfo.update(
   retriesPerChunk: Int = this.retriesPerChunk,
   optOut: Boolean = this.optOut,
   uploadJob: Deferred<Result<MuxUpload.Progress>>? = this.uploadJob,
-  statusFlow: Flow<InputStatus>?
+  statusFlow: StateFlow<UploadStatus>?
 ) = UploadInfo(
   standardizationRequested,
   remoteUri,

--- a/library/src/main/java/com/mux/video/upload/internal/UploadJobFactory.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadJobFactory.kt
@@ -73,8 +73,8 @@ internal class UploadJobFactory private constructor(
       val startTime = System.currentTimeMillis()
       try {
         // See if the file need to be converted to a standard input.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
-          && uploadInfo.standardizationRequested
+        if (uploadInfo.standardizationRequested
+          && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
         ) {
           val tcx = TranscoderContext.create(innerUploadInfo, MuxUploadManager.appContext!!)
           innerUploadInfo = tcx.process()
@@ -82,7 +82,7 @@ internal class UploadJobFactory private constructor(
             fileStream = withContext(Dispatchers.IO) {
               BufferedInputStream(FileInputStream(innerUploadInfo.standardizedFile))
             }
-            // This !! is safe by contract: process() will set the standardizedFile
+            // This !! is safe by contract: process() will set the standardizedFile if it transcoded
             fileSize = innerUploadInfo.standardizedFile!!.length()
           }
         }

--- a/library/src/main/java/com/mux/video/upload/internal/UploadJobFactory.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadJobFactory.kt
@@ -188,12 +188,14 @@ internal class UploadJobFactory private constructor(
 
         // finish up
         MainScope().launch { MuxUploadManager.jobFinished(innerUploadInfo) }
-        statusFlow.value = (UploadStatus.UploadSuccess(finalProgress))
-        Result.success(finalProgress)
+        val success = UploadStatus.UploadSuccess(finalProgress)
+        statusFlow.value = success
+        Result.success(success)
       } catch (e: Exception) {
         MuxUploadSdk.logger.e("MuxUpload", "Upload of ${innerUploadInfo.inputFile} failed", e)
         val finalState = createFinalState(fileSize, startTime)
-        statusFlow.value = UploadStatus.UploadFailed(e, finalState)
+        val failStatus = UploadStatus.UploadFailed(e, finalState)
+        statusFlow.value = failStatus
         MainScope().launch { MuxUploadManager.jobFinished(innerUploadInfo, false) }
         Result.failure(e)
       } finally {

--- a/library/src/main/java/com/mux/video/upload/internal/UploadPersistence.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadPersistence.kt
@@ -56,9 +56,7 @@ internal fun readAllCachedUploads(): List<UploadInfo> {
         retriesPerChunk = it.retriesPerChunk,
         optOut = it.optOut,
         uploadJob = null,
-        successFlow = null,
-        progressFlow = null,
-        errorFlow = null,
+        statusFlow = null,
       )
   }
 }

--- a/library/src/test/java/com/mux/video/upload/internal/UploadPersistenceTests.kt
+++ b/library/src/test/java/com/mux/video/upload/internal/UploadPersistenceTests.kt
@@ -135,9 +135,7 @@ class UploadPersistenceTests : AbsRobolectricTest() {
     retriesPerChunk = 3,
     optOut = false,
     uploadJob = null,
-    progressFlow = null,
-    successFlow = null,
-    errorFlow = null
+    statusFlow = null,
   )
 
   private fun mockContext(): Context {


### PR DESCRIPTION
Adds an `UploadStatus` object for external consumers. I kept the more-specific progress and result listeners, as this is more common in Kotlin/java than making them do `when...is` every time they want to answer a callback. The old listeners and state info are now computed from the `InputStatus` under the hood, so there's no chance of losing sync.

There is no need for an internal state object like there is in the iOS version, because we don't have to rely on callbacks and state machines to do async work. Instead, the transcode+upload coroutine just reports status as it executes