### PR TITLE
fix: the application context shouldn't be visible

### DIFF
--- a/library/src/main/java/com/mux/video/upload/MuxUploadSdk.kt
+++ b/library/src/main/java/com/mux/video/upload/MuxUploadSdk.kt
@@ -66,9 +66,10 @@ object MuxUploadSdk {
   @Suppress("unused")
   @JvmOverloads
   fun initialize(appContext: Context, resumeStoppedUploads: Boolean = true) {
-    MuxUploadManager.appContext = appContext;
-    initializeUploadPersistence(appContext)
-    UploadMetrics.initialize(appContext)
+    val realAppContext = appContext.applicationContext // Just in case they give us something else
+    MuxUploadManager.appContext = realAppContext
+    initializeUploadPersistence(realAppContext)
+    UploadMetrics.initialize(realAppContext)
     if (resumeStoppedUploads) {
       MuxUploadManager.resumeAllCachedJobs()
     }

--- a/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
@@ -29,10 +29,11 @@ object MuxUploadManager {
   private val uploadsByFilename: MutableMap<String, UploadInfo> = mutableMapOf()
   private val observerJobsByFilename: MutableMap<String, Job> = mutableMapOf()
   private val listeners: MutableSet<UploadEventListener<List<MuxUpload>>> = mutableSetOf()
+  @Suppress("unused")
   private val logger by MuxUploadSdk::logger
 
   @JvmSynthetic
-  internal var appContext: Context? = null;
+  internal var appContext: Context? = null
 
   /**
    * Finds an in-progress, paused, or failed upload and returns a [MuxUpload] to track it, if it was

--- a/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
@@ -25,13 +25,14 @@ import java.io.File
  */
 object MuxUploadManager {
 
-  public var appContext: Context? = null;
   private val mainScope = MainScope()
-
   private val uploadsByFilename: MutableMap<String, UploadInfo> = mutableMapOf()
   private val observerJobsByFilename: MutableMap<String, Job> = mutableMapOf()
   private val listeners: MutableSet<UploadEventListener<List<MuxUpload>>> = mutableSetOf()
-  private val logger get() = MuxUploadSdk.logger
+  private val logger by MuxUploadSdk::logger
+
+  @JvmSynthetic
+  internal var appContext: Context? = null;
 
   /**
    * Finds an in-progress, paused, or failed upload and returns a [MuxUpload] to track it, if it was


### PR DESCRIPTION
This probably isn't breaking in practice. No one would use our `appContext` for anything.