### PR TITLE
Add a Dokka deploy workflow

### DIFF
--- a/.github/workflows/upload-dokka-docs.yml
+++ b/.github/workflows/upload-dokka-docs.yml
@@ -1,0 +1,59 @@
+# Workflow for updating devdocs.mux.com with new documentation every time a new version is released
+#
+# Ths workflow assumes your releases are tagged either "vX.X.X" or "X.X.X", where X is a number of any length
+#
+# REQUIRED SECRETS:
+#   AWS_DOCS_KEY
+#   AWS_DOCS_SECRET
+#   DOCS_REPO_PAT
+# REQUIRED CONFIGURATION:
+#  You have to change 'YOUR-LIB' to match a URL slug for your docs, like 'upload-android' or 'data-exoplayer'
+#  You have to supply the path to your dokka output. The default is library/build/dokka/html
+#  You may need to change the name of the Gradle task used for generating your Dokka docs
+name: Upload Dokka DevDocs
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  devdocs:
+    runs-on: ubuntu-latest
+    name: Generate and Upload Dokka Docs
+
+    env:
+      AWS_EC2_METADATA_DISABLED: true
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Parse the version out of the tag name
+        id: version
+        run: >
+          echo "version_name="$(echo ${{ github.event.release.tag_name }} | sed -E "s/^v//")"" >> $GITHUB_OUTPUT
+      - name: Configure AWS
+        run: >
+          aws configure set aws_access_key_id ${{ secrets.AWS_DOCS_KEY }};
+          aws configure set aws_secret_access_key ${{ secrets.AWS_DOCS_SECRET }}
+
+      # If you have a multi-module project or monorepo, you'll need to repeat these steps
+      # POSSIBLE CONFIGURATION: make sure the `arguments:` tag matches the correct task(s) for your project
+      - name: Build Dokka Docs
+        uses: gradle/gradle-build-action@v2.4.2
+        with:
+          arguments: 'dokkaHtmlMultiModule'
+      # REQUIRED CONFIGURATION: You have to change YOUR-LIB to a suitable URL slug for your project
+      - name: Update the docs AWS bucket
+        run: |
+          aws s3 rm --recursive "s3://mux-devdocs/media3-data/latest/"
+          aws s3 sync build/dokkaOutput s3://mux-devdocs/media3-data/${{ steps.version.outputs.version_name }}/
+          aws s3 sync build/dokkaOutput s3://mux-devdocs/media3-data/latest/
+      - name: Update the devdocs site
+        run: |
+          echo "${{ secrets.DOCS_REPO_PAT }}" | gh auth login --with-token
+          gh workflow run -R muxinc/devdocs-directory deploy-to-s3


### PR DESCRIPTION
Note that this doc site won't be as nice as the upload one. We have to do something special to generate the docs for unbundled SDKs like this one, and further configuration is required to get eg, our logo in the page

If we'd rather just try to make the docs nice now, we can, but I'm also ready to triage that for the rest of the cycle