### PR TITLE
Releases/v0.4.2

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -59,7 +59,7 @@ dependencies {
   implementation "io.github.crow-misia.libyuv:libyuv-android:0.27.0"
 
   implementation 'androidx.core:core-ktx:1.10.1'
-  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.2"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'androidx.test.ext:junit:1.1.5'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -51,6 +51,22 @@ muxDistribution {
     footer = "(c) " + new Date().format("yyyy") + " Mux, Inc. Have questions or need help?" +
             " Contact support@mux.com"
   }
+  pom {
+    description "The Mux Upload SDK for Android"
+    inceptionYear = "2023"
+    url = "https://github.com/muxinc/android-upload-sdk"
+    organization {
+      name = "Mux, Inc"
+      url = "https://www.mux.com"
+    }
+    developers {
+      developer {
+        email = "support@mux.com"
+        name = "The player and sdks team @mux"
+        organization = "Mux, inc"
+      }
+    }
+  }
 }
 
 dependencies {

--- a/library/src/main/java/com/mux/video/upload/MuxUploadSdk.kt
+++ b/library/src/main/java/com/mux/video/upload/MuxUploadSdk.kt
@@ -66,9 +66,10 @@ object MuxUploadSdk {
   @Suppress("unused")
   @JvmOverloads
   fun initialize(appContext: Context, resumeStoppedUploads: Boolean = true) {
-    MuxUploadManager.appContext = appContext;
-    initializeUploadPersistence(appContext)
-    UploadMetrics.initialize(appContext)
+    val realAppContext = appContext.applicationContext // Just in case they give us something else
+    MuxUploadManager.appContext = realAppContext
+    initializeUploadPersistence(realAppContext)
+    UploadMetrics.initialize(realAppContext)
     if (resumeStoppedUploads) {
       MuxUploadManager.resumeAllCachedJobs()
     }

--- a/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
@@ -349,8 +349,9 @@ class MuxUpload private constructor(
      * for use with Mux Video
      */
     @Suppress("unused")
-    fun standardizationRequested(enabled: Boolean) {
+    fun standardizationRequested(enabled: Boolean): Builder {
       uploadInfo.update(standardizationRequested = enabled)
+      return this
     }
 
     /**
@@ -373,8 +374,9 @@ class MuxUpload private constructor(
      * here.
      */
     @Suppress("unused")
-    fun optOutOfEventTracking(optOut: Boolean) {
+    fun optOutOfEventTracking(optOut: Boolean): Builder {
       uploadInfo.update(optOut = optOut)
+      return this
     }
 
     /**

--- a/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
@@ -25,13 +25,15 @@ import java.io.File
  */
 object MuxUploadManager {
 
-  public var appContext: Context? = null;
   private val mainScope = MainScope()
-
   private val uploadsByFilename: MutableMap<String, UploadInfo> = mutableMapOf()
   private val observerJobsByFilename: MutableMap<String, Job> = mutableMapOf()
   private val listeners: MutableSet<UploadEventListener<List<MuxUpload>>> = mutableSetOf()
-  private val logger get() = MuxUploadSdk.logger
+  @Suppress("unused")
+  private val logger by MuxUploadSdk::logger
+
+  @JvmSynthetic
+  internal var appContext: Context? = null
 
   /**
    * Finds an in-progress, paused, or failed upload and returns a [MuxUpload] to track it, if it was

--- a/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
@@ -182,5 +182,4 @@ object MuxUploadManager {
       }
     }
   }
-
 }

--- a/library/src/main/java/com/mux/video/upload/api/UploadResult.kt
+++ b/library/src/main/java/com/mux/video/upload/api/UploadResult.kt
@@ -1,0 +1,56 @@
+package com.mux.video.upload.api
+
+/**
+ * Helper class for parsing [Result] objects from [MuxUpload] in Java.
+ *
+ * Kotlin callers can use the [Result] API as normal
+ */
+class UploadResult {
+
+  companion object {
+    /**
+     * Returns true of the upload was successful,
+     * Returns false if the upload wasn't successful, or if the passed object wasn't a [Result]
+     */
+    @Suppress("unused")
+    @JvmStatic
+    fun isSuccessful(result: Result<MuxUpload.Progress>): Boolean {
+      @Suppress("USELESS_IS_CHECK") // java interprets inline classes like Result as Object
+      return if (result is Result) {
+        result.isSuccess
+      } else {
+        false
+      }
+
+    }
+
+    /**
+     * Returns the final Progress update from [MuxUpload]'s [Result] if if was successful
+     * Returns `null` if the upload was not successful, or if the passed object wasn't a result
+     */
+    @Suppress("unused")
+    @JvmStatic
+    fun getFinalProgress(result: Result<MuxUpload.Progress>): MuxUpload.Progress? {
+      @Suppress("USELESS_IS_CHECK") // java interprets inline classes like Result as Object
+      return if (result is Result) {
+       result.getOrNull()
+      } else {
+        null
+      }
+    }
+
+    /**
+     * If the Result was not successful, returns the Exception that caused the failure
+     */
+    @Suppress("unused")
+    @JvmStatic
+    fun getError(result: Result<MuxUpload.Progress>): Throwable? {
+      @Suppress("USELESS_IS_CHECK") // java interprets inline classes like Result as Object
+      return if (result is Result) {
+        result.exceptionOrNull()
+      } else {
+        null
+      }
+    }
+  }
+}

--- a/library/src/main/java/com/mux/video/upload/api/UploadStatus.kt
+++ b/library/src/main/java/com/mux/video/upload/api/UploadStatus.kt
@@ -24,6 +24,12 @@ sealed class UploadStatus {
    */
   open fun getError(): Exception? = null
 
+  /**
+   * Returns whether or not the uplod was successful
+   */
+  @Suppress("unused")
+  fun isSuccessful(): Boolean = this is UploadSuccess
+
   // Subclasses
 
   /**


### PR DESCRIPTION
## New

* feat: Add `UploadResult` class for java users to interpret Result (#73)

## Fixes

* Fix: Some methods on MuxUpload.Builder don't return Builder (#74)
* Fix: the application context shouldn't be visible (#76)
* Fix: Transcoding errors handled incorrectly (#79)



Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Emily Dixon <edixon@mux.com>
Co-authored-by: Tomislav Kordic <32546640+tomkordic@users.noreply.github.com>
Co-authored-by: GitHub <noreply@github.com>