### PR TITLE
maint: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+* @muxinc/player-and-sdks
+/CODEOWNERS @muxinc/platform-engineering


### PR DESCRIPTION
I'm hoping this automatically adds the team to code reviews, but I guess it will be nice to have either way