### PR TITLE
fix: upload success not properly cached

### DIFF
--- a/app/src/main/java/com/mux/video/vod/demo/backend/ImaginaryBackend.kt
+++ b/app/src/main/java/com/mux/video/vod/demo/backend/ImaginaryBackend.kt
@@ -56,8 +56,8 @@ object ImaginaryBackend {
   // note: You shouldn't do basic auth with hard-coded keys in a real app
   private fun basicCredential(): String = Credentials.basic(ACCESS_TOKEN_ID, ACCESS_TOKEN_SECRET)
 
-  private const val ACCESS_TOKEN_ID = "7f929b61-bb61-440e-b5eb-d3c802436119"
-  private const val ACCESS_TOKEN_SECRET = "66abYl4vrv6iKwrc5G62e6gFwXq0FDiUCB/zD2pIC/RclHoNayf1syzqUxRivZaIJu2vi2hTC5d"
+  private const val ACCESS_TOKEN_ID = "YOUR TOKEN ID HERE"
+  private const val ACCESS_TOKEN_SECRET = "YOUR TOKEN SECRET HERE"
 }
 
 private interface ImaginaryWebapp {

--- a/app/src/main/java/com/mux/video/vod/demo/backend/ImaginaryBackend.kt
+++ b/app/src/main/java/com/mux/video/vod/demo/backend/ImaginaryBackend.kt
@@ -56,8 +56,8 @@ object ImaginaryBackend {
   // note: You shouldn't do basic auth with hard-coded keys in a real app
   private fun basicCredential(): String = Credentials.basic(ACCESS_TOKEN_ID, ACCESS_TOKEN_SECRET)
 
-  private const val ACCESS_TOKEN_ID = "YOUR TOKEN ID HERE"
-  private const val ACCESS_TOKEN_SECRET = "YOUR TOKEN SECRET HERE"
+  private const val ACCESS_TOKEN_ID = "7f929b61-bb61-440e-b5eb-d3c802436119"
+  private const val ACCESS_TOKEN_SECRET = "66abYl4vrv6iKwrc5G62e6gFwXq0FDiUCB/zD2pIC/RclHoNayf1syzqUxRivZaIJu2vi2hTC5d"
 }
 
 private interface ImaginaryWebapp {

--- a/app/src/main/java/com/mux/video/vod/demo/upload/Widgets.kt
+++ b/app/src/main/java/com/mux/video/vod/demo/upload/Widgets.kt
@@ -2,8 +2,21 @@ package com.mux.video.vod.demo.upload
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
-import androidx.compose.material.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Button
+import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
@@ -59,45 +72,49 @@ private fun AppBarInner(
   startContent: (@Composable () -> Unit)? = null,
   centerContent: (@Composable () -> Unit)? = null,
 ) {
-  TopAppBar(
-    elevation = 0.dp,
+  Box(
     modifier = modifier
   ) {
-    AtFullAlpha {
-      Box(
-        modifier = Modifier.fillMaxSize(),
-      ) {
+    TopAppBar(
+      elevation = 0.dp,
+      modifier = Modifier
+    ) {
+      AtFullAlpha {
         Box(
-          Modifier
-            .fillMaxWidth()
-            .height(1.dp)
-            .background(Gray80)
-            .align(Alignment.BottomCenter)
-        )
+          modifier = Modifier.fillMaxSize(),
+        ) {
 
-        if (centerContent != null) {
-          Box(modifier = Modifier.align(Alignment.Center)) {
-            centerContent()
+          if (centerContent != null) {
+            Box(modifier = Modifier.align(Alignment.Center)) {
+              centerContent()
+            }
+          } else {
+            Icon(
+              painter = painterResource(id = R.drawable.mux_logo),
+              contentDescription = "Mux Logo",
+              modifier = modifier.align(Alignment.Center),
+            )
           }
-        } else {
-          Icon(
-            painter = painterResource(id = R.drawable.mux_logo),
-            contentDescription = "Mux Logo",
-            modifier = modifier.align(Alignment.Center),
-          )
-        }
 
-        if (startContent != null) {
-          Box(
-            modifier = Modifier
-              .align(Alignment.CenterStart)
-              .padding(16.dp)
-          ) {
-            startContent()
+          if (startContent != null) {
+            Box(
+              modifier = Modifier
+                .align(Alignment.CenterStart)
+                .padding(16.dp)
+            ) {
+              startContent()
+            }
           }
         }
       }
     }
+    Box(
+      Modifier
+        .fillMaxWidth()
+        .height(1.dp)
+        .background(Gray80)
+        .align(Alignment.BottomCenter)
+    )
   }
 }
 

--- a/app/src/main/java/com/mux/video/vod/demo/upload/screen/UploadListScreen.kt
+++ b/app/src/main/java/com/mux/video/vod/demo/upload/screen/UploadListScreen.kt
@@ -23,15 +23,24 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonColors
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PauseCircle
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.PlayCircle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
@@ -62,6 +71,7 @@ import com.mux.video.vod.demo.upload.model.extractThumbnail
 import com.mux.video.vod.demo.upload.ui.theme.Gray70
 import com.mux.video.vod.demo.upload.ui.theme.Gray90
 import com.mux.video.vod.demo.upload.ui.theme.MuxUploadSDKForAndroidTheme
+import com.mux.video.vod.demo.upload.ui.theme.Pink40
 import com.mux.video.vod.demo.upload.ui.theme.TranslucentScrim
 import com.mux.video.vod.demo.upload.ui.theme.TranslucentWhite
 import com.mux.video.vod.demo.upload.viewmodel.UploadListViewModel
@@ -130,7 +140,7 @@ private fun BodyContent(
       )
     )
   ) {
-    if (items == null || items.isEmpty()) {
+    if (items.isNullOrEmpty()) {
       CreateUploadCta(modifier = Modifier.padding(vertical = 64.dp)) { uploadClick() }
     } else {
       UploadList(items)
@@ -186,6 +196,15 @@ private fun ListItemContent(upload: MuxUpload) {
         modifier = Modifier
           .align(Alignment.BottomStart)
           .fillMaxWidth()
+      )
+      PauseButton(
+        onPause = { upload.pause() },
+        modifier = Modifier.align(Alignment.Center)
+      )
+    } else {
+      PlayButton(
+        onPlay = { upload.start(forceRestart = false) },
+        modifier = Modifier.align(Alignment.Center)
       )
     }
   } // outer Box
@@ -315,6 +334,67 @@ private fun ScreenAppBar(closeThisScreen: () -> Unit) {
 
 @Composable
 private fun screenViewModel(): UploadListViewModel = viewModel()
+
+@Composable
+private fun PauseButton(
+  onPause: () -> Unit,
+  modifier: Modifier = Modifier) {
+  TextButton(
+    onClick = onPause,
+    colors = ButtonDefaults.buttonColors(
+      backgroundColor = Color.Transparent,
+      contentColor = Pink40
+    ),
+    modifier = modifier
+  ) {
+      Icon(
+        Icons.Filled.PauseCircle,
+        contentDescription = "Start playing",
+        modifier = Modifier.size(48.dp)
+      )
+  }
+}
+
+@Composable
+private fun PlayButton(
+  onPlay: () -> Unit,
+  modifier: Modifier = Modifier) {
+  TextButton(
+    onClick = onPlay,
+    colors = ButtonDefaults.buttonColors(
+      backgroundColor = Color.Transparent,
+      contentColor = Pink40
+    ),
+    modifier = modifier
+  ) {
+    Icon(
+      Icons.Filled.PlayCircle,
+      contentDescription = "Start playing",
+      modifier = Modifier.size(48.dp)
+    )
+  }
+
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PauseButton() {
+  Box(
+    modifier = Modifier.padding(12.dp)
+  ) {
+    PauseButton(onPause = { })
+  }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PlayButton() {
+  Box(
+    modifier = Modifier.padding(12.dp)
+  ) {
+    PlayButton(onPlay = { })
+  }
+}
 
 @Preview(showBackground = true)
 @Composable

--- a/app/src/main/java/com/mux/video/vod/demo/upload/screen/UploadListScreen.kt
+++ b/app/src/main/java/com/mux/video/vod/demo/upload/screen/UploadListScreen.kt
@@ -190,7 +190,6 @@ private fun ListItemContent(upload: MuxUpload) {
     if (upload.isSuccessful) {
       DoneOverlay()
     } else if (upload.error != null) {
-      Log.w("err", "screen: Upload error", upload.error)
       ErrorOverlay(modifier = Modifier.fillMaxSize())
     } else if (upload.isRunning) {
       ProgressOverlay(

--- a/app/src/main/java/com/mux/video/vod/demo/upload/screen/UploadListScreen.kt
+++ b/app/src/main/java/com/mux/video/vod/demo/upload/screen/UploadListScreen.kt
@@ -3,6 +3,7 @@ package com.mux.video.vod.demo.upload.screen
 import android.app.Activity
 import android.content.Intent
 import android.graphics.Bitmap
+import android.util.Log
 import androidx.activity.compose.ReportDrawnWhen
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -189,6 +190,7 @@ private fun ListItemContent(upload: MuxUpload) {
     if (upload.isSuccessful) {
       DoneOverlay()
     } else if (upload.error != null) {
+      Log.w("err", "screen: Upload error", upload.error)
       ErrorOverlay(modifier = Modifier.fillMaxSize())
     } else if (upload.isRunning) {
       ProgressOverlay(

--- a/app/src/main/java/com/mux/video/vod/demo/upload/viewmodel/CreateUploadViewModel.kt
+++ b/app/src/main/java/com/mux/video/vod/demo/upload/viewmodel/CreateUploadViewModel.kt
@@ -65,7 +65,6 @@ class CreateUploadViewModel(private val app: Application) : AndroidViewModel(app
         videoState.value!!.uploadUri!!,
         videoState.value!!.chosenFile!!
       )
-        .chunkSize(1024 * 1024)
         .build()
         // Force restart when creating brand new uploads (because we're making new Direct uploads)
         .start(forceRestart = true)

--- a/app/src/main/java/com/mux/video/vod/demo/upload/viewmodel/CreateUploadViewModel.kt
+++ b/app/src/main/java/com/mux/video/vod/demo/upload/viewmodel/CreateUploadViewModel.kt
@@ -64,7 +64,9 @@ class CreateUploadViewModel(private val app: Application) : AndroidViewModel(app
       MuxUpload.Builder(
         videoState.value!!.uploadUri!!,
         videoState.value!!.chosenFile!!
-      ).build()
+      )
+        .chunkSize(1024 * 1024)
+        .build()
         // Force restart when creating brand new uploads (because we're making new Direct uploads)
         .start(forceRestart = true)
     }

--- a/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
@@ -1,6 +1,7 @@
 package com.mux.video.upload.api
 
 import android.net.Uri
+import android.util.Log
 import androidx.annotation.MainThread
 import com.mux.video.upload.MuxUploadSdk
 import com.mux.video.upload.api.MuxUpload.Builder
@@ -66,7 +67,7 @@ class MuxUpload private constructor(
   /**
    * If the upload has failed, gets the error associated with the failure
    */
-  val error get() = _error ?: uploadInfo.statusFlow?.value?.getError()
+  val error get() = _error
   private var _error: Exception? = null
 
   /**
@@ -263,7 +264,11 @@ class MuxUpload private constructor(
 
               is UploadStatus.UploadFailed -> {
                 progressListener?.onEvent(status.uploadProgress) // Make sure we're most up-to-date
-                if (status.exception !is CancellationException) {
+                Log.e("err", "upload failed", error)
+                Log.e("err", "uploadJob ${uploadInfo.uploadJob?.isCancelled}")
+                val jobWasCanceled = (uploadInfo.uploadJob?.isCancelled)
+                  ?: (error is CancellationException)
+                if (!jobWasCanceled) {
                   _error = status.exception
                   resultListener?.onEvent(Result.failure(status.exception))
                 }
@@ -397,7 +402,7 @@ class MuxUpload private constructor(
      */
     @Suppress("unused")
     fun retriesPerChunk(retries: Int): Builder {
-      uploadInfo.update(retriesPerChunk = retries)
+      uploadInfo = uploadInfo.update(retriesPerChunk = retries)
       return this
     }
 

--- a/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
@@ -250,6 +250,7 @@ class MuxUpload private constructor(
               is UploadStatus.Uploading -> { progressListener?.onEvent(status.uploadProgress) }
               is UploadStatus.UploadPaused -> { progressListener?.onEvent(status.uploadProgress) }
               is UploadStatus.UploadSuccess -> {
+                _successful = true
                 progressListener?.onEvent(status.uploadProgress)
                 resultListener?.onEvent(Result.success(status.uploadProgress))
               }

--- a/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
@@ -264,8 +264,6 @@ class MuxUpload private constructor(
 
               is UploadStatus.UploadFailed -> {
                 progressListener?.onEvent(status.uploadProgress) // Make sure we're most up-to-date
-                Log.e("err", "upload failed", error)
-                Log.e("err", "uploadJob ${uploadInfo.uploadJob?.isCancelled}")
                 val jobWasCanceled = (uploadInfo.uploadJob?.isCancelled)
                   ?: (error is CancellationException)
                 if (!jobWasCanceled) {

--- a/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
@@ -247,13 +247,20 @@ class MuxUpload private constructor(
 
             // Notify the old listeners
             when (status) {
-              is UploadStatus.Uploading -> { progressListener?.onEvent(status.uploadProgress) }
-              is UploadStatus.UploadPaused -> { progressListener?.onEvent(status.uploadProgress) }
+              is UploadStatus.Uploading -> {
+                progressListener?.onEvent(status.uploadProgress)
+              }
+
+              is UploadStatus.UploadPaused -> {
+                progressListener?.onEvent(status.uploadProgress)
+              }
+
               is UploadStatus.UploadSuccess -> {
                 _successful = true
                 progressListener?.onEvent(status.uploadProgress)
                 resultListener?.onEvent(Result.success(status.uploadProgress))
               }
+
               is UploadStatus.UploadFailed -> {
                 progressListener?.onEvent(status.uploadProgress) // Make sure we're most up-to-date
                 if (status.exception !is CancellationException) {
@@ -261,7 +268,8 @@ class MuxUpload private constructor(
                   resultListener?.onEvent(Result.failure(status.exception))
                 }
               }
-              else -> { } // no relevant info
+
+              else -> {} // no relevant info
             }
           }
         }
@@ -336,6 +344,7 @@ class MuxUpload private constructor(
       uploadJob = null,
       statusFlow = null,
     )
+
     /**
      * Allow Mux to manage and remember the state of this upload
      */
@@ -351,7 +360,7 @@ class MuxUpload private constructor(
      */
     @Suppress("unused")
     fun standardizationRequested(enabled: Boolean): Builder {
-      uploadInfo.update(standardizationRequested = enabled)
+      uploadInfo = uploadInfo.update(standardizationRequested = enabled)
       return this
     }
 
@@ -363,7 +372,7 @@ class MuxUpload private constructor(
      */
     @Suppress("unused")
     fun chunkSize(sizeBytes: Int): Builder {
-      uploadInfo.update(chunkSize = sizeBytes)
+      uploadInfo = uploadInfo.update(chunkSize = sizeBytes)
       return this
     }
 
@@ -376,7 +385,7 @@ class MuxUpload private constructor(
      */
     @Suppress("unused")
     fun optOutOfEventTracking(optOut: Boolean): Builder {
-      uploadInfo.update(optOut = optOut)
+      uploadInfo = uploadInfo.update(optOut = optOut)
       return this
     }
 
@@ -404,7 +413,7 @@ class MuxUpload private constructor(
      * [MuxUploadManager]
      */
     @JvmSynthetic
-    internal fun create(uploadInfo: UploadInfo, initialStatus: UploadStatus = UploadStatus.Ready)
-      = MuxUpload(uploadInfo = uploadInfo, initialStatus = initialStatus)
+    internal fun create(uploadInfo: UploadInfo, initialStatus: UploadStatus = UploadStatus.Ready) =
+      MuxUpload(uploadInfo = uploadInfo, initialStatus = initialStatus)
   }
 }

--- a/library/src/main/java/com/mux/video/upload/api/UploadStatus.kt
+++ b/library/src/main/java/com/mux/video/upload/api/UploadStatus.kt
@@ -35,19 +35,19 @@ sealed class UploadStatus {
   /**
    * This upload hos not been started. It is ready to start by calling [MuxUpload.start]
    */
-  object Ready: UploadStatus()
+  data object Ready: UploadStatus()
 
   /**
    * This upload has been started via [MuxUpload.start] but has not yet started processing anything
    */
-  object Started: UploadStatus()
+  data object Started: UploadStatus()
 
   /**
    * This upload is being prepared. If standardization is required, it is done during this step
    *
    * @see MuxUpload.Builder.standardizationRequested
    */
-  object Preparing: UploadStatus()
+  data object Preparing: UploadStatus()
 
   /**
    * The upload is currently being sent to Mux Video. The progress is available

--- a/library/src/main/java/com/mux/video/upload/internal/ChunkWorker.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/ChunkWorker.kt
@@ -76,7 +76,8 @@ internal class ChunkWorker private constructor(
       }
     }
 
-    return tryUpload(0).getOrThrow().also { writeUploadState(uploadInfo, it) }
+    return tryUpload(0).getOrThrow()
+      .also { writeUploadState(uploadInfo, it) }
   }
 
   @Throws


### PR DESCRIPTION
Also:
* fixes `MuxUpload.Builder`'s setter methods not having an effect
* updates the Example App to have a pause/resume button again
* code-reformatting `MuxUpload`