### PR TITLE
fix: upload success reported as failure in some cases

### DIFF
--- a/library/src/main/java/com/mux/video/upload/internal/UploadMetrics.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadMetrics.kt
@@ -24,16 +24,6 @@ internal class UploadMetrics private constructor() {
 
   private val logger get() = MuxUploadSdk.logger
 
-
-  private fun formatMilliseconds(ms:Long):String {
-    return String.format("%02d:%02d:%02d",
-      TimeUnit.MILLISECONDS.toHours(ms),
-      TimeUnit.MILLISECONDS.toMinutes(ms) -
-              TimeUnit.HOURS.toMinutes(TimeUnit.MILLISECONDS.toHours(ms)), // The change is in this line
-      TimeUnit.MILLISECONDS.toSeconds(ms) -
-              TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(ms)));
-  }
-
   private suspend fun getEventInfo(startTimeMillis: Long,
                                    startTimeKey: String,
                                    endTimeMillis: Long,
@@ -125,8 +115,8 @@ internal class UploadMetrics private constructor() {
     maximumResolution:String,
     sessionId: String,
     uploadInfo: UploadInfo
-  ) {
-    var body = JSONObject()
+  ) = runCatching {
+    val body = JSONObject()
     body.put("type", "upload_input_standardization_succeeded")
     body.put("session_id", sessionId)
     body.put("version", "1")
@@ -149,8 +139,8 @@ internal class UploadMetrics private constructor() {
     maximumResolution:String,
     sessionId: String,
     uploadInfo: UploadInfo
-  ) {
-    var body = JSONObject()
+  ) = runCatching {
+    val body = JSONObject()
     body.put("type", "upload_input_standardization_failed")
     body.put("session_id", sessionId)
     body.put("version", "1")
@@ -172,8 +162,8 @@ internal class UploadMetrics private constructor() {
     inputFileDurationMs: Long,
     sessionId: String,
     uploadInfo: UploadInfo
-  ) {
-    var body = JSONObject()
+  ) = runCatching {
+    val body = JSONObject()
     body.put("type", "upload_succeeded")
     body.put("session_id", sessionId)
     body.put("version", "1")
@@ -193,8 +183,8 @@ internal class UploadMetrics private constructor() {
     errorDescription:String,
     sessionId: String,
     uploadInfo: UploadInfo
-  ) {
-    var body = JSONObject()
+  ) = runCatching {
+    val body = JSONObject()
     body.put("type", "uploadfailed")
     body.put("session_id", sessionId)
     body.put("version", "1")


### PR DESCRIPTION
If the metrics server is down, just swallow the error. 