### PR TITLE
4K standardization

### DIFF
--- a/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUpload.kt
@@ -4,6 +4,8 @@ import android.net.Uri
 import androidx.annotation.MainThread
 import com.mux.video.upload.MuxUploadSdk
 import com.mux.video.upload.api.MuxUpload.Builder
+import com.mux.video.upload.internal.InputStandardization
+import com.mux.video.upload.internal.MaximumResolution
 import com.mux.video.upload.internal.UploadInfo
 import com.mux.video.upload.internal.update
 import kotlinx.coroutines.*
@@ -330,7 +332,6 @@ class MuxUpload private constructor(
       inputFile = videoFile,
       chunkSize = 8 * 1024 * 1024, // GCP recommends at least 8M chunk size
       retriesPerChunk = 3,
-      standardizationRequested = true,
       optOut = false,
       uploadJob = null,
       statusFlow = null,
@@ -349,8 +350,18 @@ class MuxUpload private constructor(
      * for use with Mux Video
      */
     @Suppress("unused")
+    fun standardizationRequested(enabled: Boolean, maxResolution: MaximumResolution): Builder {
+      uploadInfo.update(InputStandardization(enabled, maxResolution))
+      return this
+    }
+
+    /**
+     * If requested, the Upload SDK will try to standardize the input file in order to optimize it
+     * for use with Mux Video
+     */
+    @Suppress("unused")
     fun standardizationRequested(enabled: Boolean): Builder {
-      uploadInfo.update(standardizationRequested = enabled)
+      uploadInfo.update(InputStandardization(enabled))
       return this
     }
 

--- a/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
@@ -7,6 +7,34 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.flow.StateFlow
 import java.io.File
 
+enum class MaximumResolution(val width: Int, val height: Int) {
+  /// By default the standardized input will be
+  /// scaled down to 1920x1080 (1080p) from a larger
+  /// size. Inputs with smaller dimensions won't be
+  /// scaled up.
+  Default(1920, 1080),
+  /// The standardized input will be scaled down
+  /// to 1280x720 (720p) from a larger size. Inputs
+  /// with smaller dimensions won't be scaled up.
+  Preset1280x720(1280, 1080),  // 720p
+  /// The standardized input will be scaled down
+  /// to 1920x1080 (1080p) from a larger size. Inputs
+  /// with smaller dimensions won't be scaled up.
+  Preset1920x1080(1920, 1080), // 1080p
+  /// The standardized input will be scaled down
+  /// to 3840x2160 (2160p/4K) from a larger size.
+  /// Inputs with smaller dimensions won't be scaled
+  /// up.
+  Preset3840x2160(3840, 2160) // 2160p
+}
+
+data class InputStandardization(
+  @JvmSynthetic internal val standardizationRequested: Boolean = true,
+  @JvmSynthetic internal val maximumResolution: MaximumResolution = MaximumResolution.Default,
+) {
+
+}
+
 /**
  * This object is the SDK's internal representation of an upload that is in-progress. The public
  * object is [MuxUpload], which is backed by an instance of this object.
@@ -18,7 +46,7 @@ import java.io.File
  * Job and Flows populated
  */
 internal data class UploadInfo(
-  @JvmSynthetic internal val standardizationRequested: Boolean = true,
+  @JvmSynthetic internal val inputStandardization: InputStandardization = InputStandardization(),
   @JvmSynthetic internal val remoteUri: Uri,
   @JvmSynthetic internal val inputFile: File,
   @JvmSynthetic internal val standardizedFile: File? = null,
@@ -29,6 +57,7 @@ internal data class UploadInfo(
   @JvmSynthetic internal val statusFlow: StateFlow<UploadStatus>?,
 ) {
   fun isRunning(): Boolean = uploadJob?.isActive ?: false
+  fun isStandardizationRequested(): Boolean = inputStandardization.standardizationRequested
 }
 
 /**
@@ -37,7 +66,7 @@ internal data class UploadInfo(
  */
 @JvmSynthetic
 internal fun UploadInfo.update(
-  standardizationRequested: Boolean = this.standardizationRequested,
+  inputStandardization: InputStandardization = InputStandardization(),
   remoteUri: Uri = this.remoteUri,
   file: File = this.inputFile,
   standardizedFile: File? = this.standardizedFile,
@@ -47,7 +76,7 @@ internal fun UploadInfo.update(
   uploadJob: Deferred<Result<UploadStatus>>? = this.uploadJob,
   statusFlow: StateFlow<UploadStatus>? = this.statusFlow,
 ) = UploadInfo(
-  standardizationRequested,
+  inputStandardization,
   remoteUri,
   file,
   standardizedFile,

--- a/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
@@ -9,10 +9,11 @@ import java.io.File
 
 @Suppress("unused")
 enum class MaximumResolution(val width: Int, val height: Int) {
-  /** By default the standardized input will be
+  /**
+   * By default the standardized input will be
    * scaled down to 1920x1080 (1080p) from a larger
    * size. Inputs with smaller dimensions won't be
-   *  scaled up.
+   * scaled up.
    */
   Default(1920, 1080),
 
@@ -23,13 +24,15 @@ enum class MaximumResolution(val width: Int, val height: Int) {
    */
   Preset1280x720(1280, 720),  // 720p
 
-  /* The standardized input will be scaled down
+  /**
+   * The standardized input will be scaled down
    * to 1920x1080 (1080p) from a larger size. Inputs
-    with smaller dimensions won't be scaled up.
+   * with smaller dimensions won't be scaled up.
    */
   Preset1920x1080(1920, 1080), // 1080p
 
-  /** The standardized input will be scaled down
+  /**
+   *  The standardized input will be scaled down
    *  to 3840x2160 (2160p/4K) from a larger size.
    *  Inputs with smaller dimensions won't be scaled
    *  up.

--- a/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
@@ -16,7 +16,7 @@ enum class MaximumResolution(val width: Int, val height: Int) {
   /// The standardized input will be scaled down
   /// to 1280x720 (720p) from a larger size. Inputs
   /// with smaller dimensions won't be scaled up.
-  Preset1280x720(1280, 1080),  // 720p
+  Preset1280x720(1280, 720),  // 720p
   /// The standardized input will be scaled down
   /// to 1920x1080 (1080p) from a larger size. Inputs
   /// with smaller dimensions won't be scaled up.

--- a/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadInfo.kt
@@ -7,24 +7,33 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.flow.StateFlow
 import java.io.File
 
+@Suppress("unused")
 enum class MaximumResolution(val width: Int, val height: Int) {
-  /// By default the standardized input will be
-  /// scaled down to 1920x1080 (1080p) from a larger
-  /// size. Inputs with smaller dimensions won't be
-  /// scaled up.
+  /** By default the standardized input will be
+   * scaled down to 1920x1080 (1080p) from a larger
+   * size. Inputs with smaller dimensions won't be
+   *  scaled up.
+   */
   Default(1920, 1080),
-  /// The standardized input will be scaled down
-  /// to 1280x720 (720p) from a larger size. Inputs
-  /// with smaller dimensions won't be scaled up.
+
+  /**
+   * The standardized input will be scaled down
+   * to 1280x720 (720p) from a larger size. Inputs
+   * with smaller dimensions won't be scaled up.
+   */
   Preset1280x720(1280, 720),  // 720p
-  /// The standardized input will be scaled down
-  /// to 1920x1080 (1080p) from a larger size. Inputs
-  /// with smaller dimensions won't be scaled up.
+
+  /* The standardized input will be scaled down
+   * to 1920x1080 (1080p) from a larger size. Inputs
+    with smaller dimensions won't be scaled up.
+   */
   Preset1920x1080(1920, 1080), // 1080p
-  /// The standardized input will be scaled down
-  /// to 3840x2160 (2160p/4K) from a larger size.
-  /// Inputs with smaller dimensions won't be scaled
-  /// up.
+
+  /** The standardized input will be scaled down
+   *  to 3840x2160 (2160p/4K) from a larger size.
+   *  Inputs with smaller dimensions won't be scaled
+   *  up.
+   */
   Preset3840x2160(3840, 2160) // 2160p
 }
 

--- a/library/src/main/java/com/mux/video/upload/internal/UploadJobFactory.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadJobFactory.kt
@@ -78,7 +78,7 @@ internal class UploadJobFactory private constructor(
       val startTime = System.currentTimeMillis()
       try {
         // See if the file need to be converted to a standard input.
-        if (uploadInfo.standardizationRequested
+        if (uploadInfo.isStandardizationRequested()
           && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
         ) {
           statusFlow.value = UploadStatus.Preparing

--- a/library/src/main/java/com/mux/video/upload/internal/UploadMetrics.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadMetrics.kt
@@ -179,7 +179,7 @@ internal class UploadMetrics private constructor() {
     body.put("version", "1")
     val data = getEventInfo(startTimeMillis, "upload_start_time", endTimeMillis,
       "upload_end_time", inputFileDurationMs, uploadInfo)
-    data.put("input_standardization_requested", uploadInfo.standardizationRequested
+    data.put("input_standardization_requested", uploadInfo.isStandardizationRequested()
             && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
     body.put("data", data)
     sendPost(body)
@@ -200,7 +200,7 @@ internal class UploadMetrics private constructor() {
     body.put("version", "1")
     val data = getEventInfo(startTimeMillis, "upload_start_time", endTimeMillis,
       "upload_end_time", inputFileDurationMs, uploadInfo)
-    data.put("input_standardization_requested", uploadInfo.standardizationRequested
+    data.put("input_standardization_requested", uploadInfo.isStandardizationRequested()
             && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
     data.put("error_description", errorDescription)
     body.put("data", data)

--- a/library/src/main/java/com/mux/video/upload/internal/options/DirectUploadOptions.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/options/DirectUploadOptions.kt
@@ -1,5 +1,0 @@
-package com.mux.video.upload.internal.options
-
-class DirectUploadOptions {
-
-}

--- a/library/src/main/java/com/mux/video/upload/internal/options/DirectUploadOptions.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/options/DirectUploadOptions.kt
@@ -1,0 +1,5 @@
+package com.mux.video.upload.internal.options
+
+class DirectUploadOptions {
+
+}


### PR DESCRIPTION
According to this doc: https://docs.mux.com/guides/minimize-processing-time#standard-input-specs and @andrewjl-mux Release branch: https://github.com/muxinc/swift-upload-sdk/tree/releases/v1.0.0