### PR TITLE
chore: update to kotlin 2.0.10 + others

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 android {
   namespace "com.mux.video.vod.demo"
-  compileSdk 34
+  compileSdk 35
 
   defaultConfig {
     applicationId "com.mux.video.vod.demo"
     minSdk 21
-    targetSdkVersion 34
+    targetSdkVersion 35
     versionCode 1
     versionName "1.0"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   id 'com.android.application'
   id 'org.jetbrains.kotlin.android'
+  id "org.jetbrains.kotlin.plugin.compose"
 }
 
 android {
@@ -37,9 +38,6 @@ android {
     viewBinding true
     compose true
   }
-  composeOptions {
-    kotlinCompilerExtensionVersion '1.5.14'
-  }
   packagingOptions {
     resources {
       excludes += '/META-INF/{AL2.0,LGPL2.1}'
@@ -51,24 +49,24 @@ dependencies {
 
   implementation project(':library')
 
-  implementation 'androidx.appcompat:appcompat:1.6.1'
-  implementation 'com.google.android.material:material:1.10.0'
+  implementation 'androidx.appcompat:appcompat:1.7.0'
+  implementation 'com.google.android.material:material:1.12.0'
   implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-  implementation 'androidx.activity:activity-ktx:1.8.2'
-  implementation "androidx.fragment:fragment-ktx:1.6.2"
-  implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0"
-  implementation 'androidx.core:core-ktx:1.12.0'
+  implementation 'androidx.activity:activity-ktx:1.9.1'
+  implementation "androidx.fragment:fragment-ktx:1.8.2"
+  implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.4"
+  implementation 'androidx.core:core-ktx:1.13.1'
   implementation 'net.danlew:android.joda:2.12.7'
-  implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
-  implementation 'androidx.activity:activity-compose:1.8.0'
-  implementation "androidx.compose.ui:ui:$compose_ui_version"
-  implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
-  implementation "androidx.compose.runtime:runtime-livedata:$compose_ui_version"
-  implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$compose_ui_version"
-  implementation "androidx.compose.material:material-icons-extended:$compose_ui_version"
+  implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.8.4'
+  implementation 'androidx.activity:activity-compose:1.9.1'
+  implementation "androidx.compose.ui:ui:1.6.8"
+  implementation "androidx.compose.ui:ui-tooling-preview:1.6.8"
+  implementation "androidx.compose.runtime:runtime-livedata:1.6.8"
+  implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.8.4"
+  implementation "androidx.compose.material:material-icons-extended:1.6.8"
   implementation "com.google.accompanist:accompanist-systemuicontroller:0.34.0"
 
-  implementation 'androidx.compose.material:material:1.6.1'
+  implementation 'androidx.compose.material:material:1.6.8'
 
   implementation "com.squareup.okhttp3:logging-interceptor:4.12.0"
   implementation "com.squareup.okhttp3:okhttp:4.12.0"
@@ -77,9 +75,9 @@ dependencies {
   implementation 'com.squareup.retrofit2:converter-scalars:2.9.0'
 
   testImplementation 'junit:junit:4.13.2'
-  androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-  androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"
-  debugImplementation "androidx.compose.ui:ui-tooling:$compose_ui_version"
-  debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_ui_version"
+  androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+  androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.6.8"
+  debugImplementation "androidx.compose.ui:ui-tooling:1.6.8"
+  debugImplementation "androidx.compose.ui:ui-test-manifest:1.6.8"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,9 @@
-buildscript {
-  ext {
-    compose_ui_version = '1.5.3'
-  }
-}// Top-level build file where you can add configuration options common to all sub-projects/modules.
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-  id 'com.android.application' version '8.4.2' apply false
-  id 'com.android.library' version '8.4.2' apply false
-  id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
+  id 'com.android.application' version '8.5.2' apply false
+  id 'com.android.library' version '8.5.2' apply false
+  id 'org.jetbrains.kotlin.android' version '2.0.10' apply false
+  id 'org.jetbrains.kotlin.plugin.compose' version '2.0.10' apply false
   id 'com.mux.gradle.android.mux-android-distribution' version '1.2.1' apply false
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 19 16:04:49 PST 2023
+#Tue Aug 20 17:09:10 PDT 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,11 +6,10 @@ plugins {
 
 android {
   namespace 'com.mux.video.upload'
-  compileSdk 34
+  compileSdk 35
 
   defaultConfig {
     minSdk 16
-    targetSdkVersion 34
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"
@@ -75,13 +74,13 @@ muxDistribution {
 dependencies {
   implementation "com.squareup.okhttp3:logging-interceptor:4.12.0"
   implementation "com.squareup.okhttp3:okhttp:4.12.0"
-  implementation "io.github.crow-misia.libyuv:libyuv-android:0.29.0"
+  implementation "io.github.crow-misia.libyuv:libyuv-android:0.34.0"
 
-  implementation 'androidx.core:core-ktx:1.12.0'
-  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
+  implementation 'androidx.core:core-ktx:1.13.1'
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
 
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test.ext:junit:1.1.5'
+  testImplementation 'androidx.test.ext:junit:1.2.1'
   testImplementation "io.mockk:mockk:1.13.9"
   testImplementation 'org.robolectric:robolectric:4.11.1'
 }

--- a/library/src/main/java/com/mux/video/upload/internal/UploadMetrics.kt
+++ b/library/src/main/java/com/mux/video/upload/internal/UploadMetrics.kt
@@ -217,7 +217,7 @@ internal class UploadMetrics private constructor() {
         appContext.packageManager.getPackageInfo(appContext.packageName, 0)
       }
       appName = packageInfo.packageName
-      appVersion = packageInfo.versionName
+      appVersion = packageInfo.versionName ?: "unknown"
     }
   }
 }


### PR DESCRIPTION
Updating to Kotlin 2.0 simplifies Compose integration, among other things

Kotlin/JVM updates are backward-compatible (it's all compatible bytecode underneath), so there's no downside