### PR TITLE
fix: crash on app resume when system clears cached upload files

### DIFF
--- a/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
@@ -60,6 +60,13 @@ object MuxUploadManager {
   @MainThread
   fun resumeAllCachedJobs(): List<MuxUpload> {
     return readAllCachedUploads()
+       .filter { uploadInfo ->
+         val exists = uploadInfo.inputFile.exists()
+         if (!exists) {
+             forgetUploadState(uploadInfo)
+         }
+         exists
+       }
       .onEach { uploadInfo -> startJob(uploadInfo, restart = false) }
       .map { MuxUpload.create(it) }
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, localized change to upload resume logic that only skips and clears persisted state for uploads whose input file no longer exists.
> 
> **Overview**
> Prevents crashes when resuming cached uploads by checking `uploadInfo.inputFile.exists()` in `resumeAllCachedJobs()`.
> 
> Cached entries whose files have been deleted by the system are now skipped and their persisted state is removed via `forgetUploadState(...)`, while remaining uploads resume as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbbc6ff3897af1b5767df219714e646008c43a9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->