### PR TITLE
Releases/v1.0.4

### DIFF
--- a/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
+++ b/library/src/main/java/com/mux/video/upload/api/MuxUploadManager.kt
@@ -60,6 +60,13 @@ object MuxUploadManager {
   @MainThread
   fun resumeAllCachedJobs(): List<MuxUpload> {
     return readAllCachedUploads()
+       .filter { uploadInfo ->
+         val exists = uploadInfo.inputFile.exists()
+         if (!exists) {
+             forgetUploadState(uploadInfo)
+         }
+         exists
+       }
       .onEach { uploadInfo -> startJob(uploadInfo, restart = false) }
       .map { MuxUpload.create(it) }
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small change in `resumeAllCachedJobs` to skip missing files and clean persisted state; main risk is unintentionally forgetting an upload if file existence checks behave unexpectedly on certain storage setups.
> 
> **Overview**
> Fixes a crash on app resume by having `MuxUploadManager.resumeAllCachedJobs()` **skip cached uploads whose `inputFile` no longer exists**.
> 
> When a cached upload’s file is missing, it now calls `forgetUploadState(uploadInfo)` to purge the persisted entry before resuming the remaining jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce02faaded97b01d311cfd94d2091759215daff4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Improvements

* fix: crash on app resume when system clears cached upload files (#161)



Co-authored-by: Emily Dixon <edixon@mux.com>
Co-authored-by: GitHub <noreply@github.com>